### PR TITLE
Upgrade the Transformer model

### DIFF
--- a/config/models/transformer.py
+++ b/config/models/transformer.py
@@ -11,8 +11,9 @@ def model():
       target_inputter=onmt.inputters.WordEmbedder(
           vocabulary_file_key="target_words_vocabulary",
           embedding_size=512),
-      num_layers=4,
+      num_layers=6,
       num_heads=8,
       ffn_inner_dim=2048,
       dropout=0.1,
-      attention_dropout=0.0)
+      attention_dropout=0.1,
+      relu_dropout=0.1)

--- a/config/optim/adam_with_noam_decay.yml
+++ b/config/optim/adam_with_noam_decay.yml
@@ -2,7 +2,7 @@
 
 params:
   optimizer: AdamOptimizer
-  learning_rate: 0.0 # The value is ignored.
+  learning_rate: 1 # The scale constant.
   decay_type: noam_decay
   decay_rate: 512 # Model dimension.
   decay_steps: 4000 # Warmup steps.

--- a/opennmt/models/transformer.py
+++ b/opennmt/models/transformer.py
@@ -18,7 +18,8 @@ class Transformer(SequenceToSequence):
                num_heads,
                ffn_inner_dim,
                dropout=0.1,
-               attention_dropout=0.0,
+               attention_dropout=0.1,
+               relu_dropout=0.1,
                position_encoder=PositionEmbedder(),
                name="transformer"):
     """Initializes a Transformer model.
@@ -34,6 +35,8 @@ class Transformer(SequenceToSequence):
       ffn_inner_dim: The inner dimension of the feed forward layers.
       dropout: The probability to drop units in each layer output.
       attention_dropout: The probability to drop units from the attention.
+      relu_dropout: The probability to drop units from the ReLU activation in
+        the feed forward layer.
       position_encoder: A :class:`opennmt.utils.position.PositionEncoder` to
         apply on the inputs.
       name: The name of this model.
@@ -44,7 +47,7 @@ class Transformer(SequenceToSequence):
         ffn_inner_dim=ffn_inner_dim,
         dropout=dropout,
         attention_dropout=attention_dropout,
-        keep_layers_output=True,
+        relu_dropout=relu_dropout,
         position_encoder=position_encoder)
     decoder = SelfAttentionDecoder(
         num_layers,
@@ -52,6 +55,7 @@ class Transformer(SequenceToSequence):
         ffn_inner_dim=ffn_inner_dim,
         dropout=dropout,
         attention_dropout=attention_dropout,
+        relu_dropout=relu_dropout,
         position_encoder=position_encoder)
 
     super(Transformer, self).__init__(

--- a/opennmt/utils/decay.py
+++ b/opennmt/utils/decay.py
@@ -16,7 +16,7 @@ def noam_decay(learning_rate,
   The semantic of the arguments are changed accordingly.
 
   Args:
-    learning_rate: The current learning rate.
+    learning_rate: The scale constant.
     global_step: The current learning step.
     decay_steps: The warmup steps.
     decay_rate: The model dimension.
@@ -26,14 +26,14 @@ def noam_decay(learning_rate,
   Returns:
     The learning rate for the step :obj:`global_step`.
   """
-  _ = learning_rate
   _ = staircase
   _ = name
 
-  global_step = tf.cast(global_step, tf.float32)
-  decay_rate = tf.cast(decay_rate, tf.float32)
-  decay_steps = tf.cast(decay_steps, tf.float32)
+  scale = tf.cast(learning_rate, tf.float32)
+  step = tf.cast(global_step, tf.float32) + 1
+  hidden_size = tf.cast(decay_rate, tf.float32)
+  warmup_steps = tf.cast(decay_steps, tf.float32)
 
-  return (tf.pow(decay_rate, -0.5)
-          * tf.minimum(tf.pow(global_step, -0.5),
-                       global_step * tf.pow(decay_steps, -1.5)))
+  return (scale
+          * tf.pow(hidden_size, -0.5)
+          * tf.minimum(tf.pow(step, -0.5), step * tf.pow(warmup_steps, -1.5)))


### PR DESCRIPTION
This makes the implementation closer to the configuration used in "transformer_base" in Tensor2Tensor.

In particular:

* the decoder only attends the final encoder output
* the layer normalization is moved to the block inputs
* the output of the encoder and decoder is also normalized
* a dropout is applied in the feed forward layer
* the learning rate can be used as a scale factor in the Noam decay