### PR TITLE
Shard the dataset for small sample buffer sizes

### DIFF
--- a/opennmt/inputters/inputter.py
+++ b/opennmt/inputters/inputter.py
@@ -84,6 +84,18 @@ class Inputter(object):
     """
     raise NotImplementedError()
 
+  @abc.abstractmethod
+  def get_dataset_size(self, data_file):
+    """Returns the size of the dataset.
+
+    Args:
+      data_file: The data file.
+
+    Returns:
+      The total size.
+    """
+    raise NotImplementedError()
+
   def get_serving_input_receiver(self):
     """Returns a serving input receiver for this inputter.
 
@@ -221,6 +233,9 @@ class MultiInputter(Inputter):
   @abc.abstractmethod
   def make_dataset(self, data_file):
     raise NotImplementedError()
+
+  def get_dataset_size(self, data_file):
+    return self.inputters[0].get_dataset_size(data_file)
 
   def initialize(self, metadata):
     for inputter in self.inputters:

--- a/opennmt/inputters/record_inputter.py
+++ b/opennmt/inputters/record_inputter.py
@@ -35,6 +35,9 @@ class SequenceRecordInputter(Inputter):
   def make_dataset(self, data_file):
     return tf.data.TFRecordDataset(data_file)
 
+  def get_dataset_size(self, data_file):
+    return sum(1 for _ in tf.python_io.tf_record_iterator(data_file))
+
   def _get_serving_input(self):
     receiver_tensors = {
         "tensor": tf.placeholder(tf.float32, shape=(None, None, self.input_depth)),

--- a/opennmt/inputters/text_inputter.py
+++ b/opennmt/inputters/text_inputter.py
@@ -215,6 +215,9 @@ class TextInputter(Inputter):
   def make_dataset(self, data_file):
     return tf.data.TextLineDataset(data_file)
 
+  def get_dataset_size(self, data_file):
+    return count_lines(data_file)
+
   def initialize(self, metadata):
     self.tokenizer.initialize(metadata)
 

--- a/opennmt/models/model.py
+++ b/opennmt/models/model.py
@@ -2,7 +2,6 @@
 
 from __future__ import print_function
 
-import time
 import abc
 import six
 
@@ -342,6 +341,18 @@ class Model(object):
     return None
 
   @abc.abstractmethod
+  def _get_dataset_size(self, features_file):
+    """Returns the size of the dataset.
+
+    Args:
+      features_file: The file of features.
+
+    Returns:
+      The total size.
+    """
+    raise NotImplementedError()
+
+  @abc.abstractmethod
   def _get_features_builder(self, features_file):
     """Returns the recipe to build features.
 
@@ -399,7 +410,16 @@ class Model(object):
           feat_padded_shapes_fn(), labels_padded_shapes_fn())
 
     if mode == tf.estimator.ModeKeys.TRAIN:
-      dataset = dataset.shuffle(sample_buffer_size, seed=int(time.time()))
+      # When the sample buffer size is smaller than the dataset size, randomly
+      # select a shard of the dataset. This ensures that all parts of the
+      # dataset can be seen when the evaluation frequency is high.
+      dataset_size = self._get_dataset_size(features_file)
+      num_shards = -(-dataset_size // sample_buffer_size)  # Ceil division.
+      if num_shards > 1:
+        shard_index = tf.random_uniform(
+            [], minval=0, maxval=num_shards, dtype=tf.int64)
+        dataset = dataset.shard(num_shards, shard_index)
+      dataset = dataset.shuffle(sample_buffer_size)
 
     dataset = dataset.map(
         process_fn,

--- a/opennmt/models/sequence_classifier.py
+++ b/opennmt/models/sequence_classifier.py
@@ -52,6 +52,9 @@ class SequenceClassifier(Model):
   def _get_features_length(self, features):
     return self.inputter.get_length(features)
 
+  def _get_dataset_size(self, features_file):
+    return self.inputter.get_dataset_size(features_file)
+
   def _get_features_builder(self, features_file):
     dataset = self.inputter.make_dataset(features_file)
     process_fn = self.inputter.process

--- a/opennmt/models/sequence_tagger.py
+++ b/opennmt/models/sequence_tagger.py
@@ -55,6 +55,9 @@ class SequenceTagger(Model):
   def _get_features_length(self, features):
     return self.inputter.get_length(features)
 
+  def _get_dataset_size(self, features_file):
+    return self.inputter.get_dataset_size(features_file)
+
   def _get_features_builder(self, features_file):
     dataset = self.inputter.make_dataset(features_file)
     process_fn = self.inputter.process

--- a/opennmt/models/sequence_to_sequence.py
+++ b/opennmt/models/sequence_to_sequence.py
@@ -102,6 +102,9 @@ class SequenceToSequence(Model):
   def _get_labels_length(self, labels):
     return self.target_inputter.get_length(labels)
 
+  def _get_dataset_size(self, features_file):
+    return self.source_inputter.get_dataset_size(features_file)
+
   def _get_features_builder(self, features_file):
     dataset = self.source_inputter.make_dataset(features_file)
     process_fn = self.source_inputter.process


### PR DESCRIPTION
When the `sample_buffer_size` is small compared to the training data size and the evaluation frequency is high, the training will consistently miss a portion of the dataset.

This change randomly selects a shard of the dataset to ensure that the full dataset can be seen during the training.