### PR TITLE
Inherit dtype from the inputter

### DIFF
--- a/config/models/nmt_medium_fp16.py
+++ b/config/models/nmt_medium_fp16.py
@@ -1,0 +1,32 @@
+"""Defines a medium-sized bidirectional LSTM encoder-decoder model with
+experimental FP16 data type.
+"""
+
+import tensorflow as tf
+import opennmt as onmt
+
+def model():
+  return onmt.models.SequenceToSequence(
+      source_inputter=onmt.inputters.WordEmbedder(
+          vocabulary_file_key="source_words_vocabulary",
+          embedding_size=512,
+          dtype=tf.float16),
+      target_inputter=onmt.inputters.WordEmbedder(
+          vocabulary_file_key="target_words_vocabulary",
+          embedding_size=512,
+          dtype=tf.float16),
+      encoder=onmt.encoders.BidirectionalRNNEncoder(
+          num_layers=4,
+          num_units=512,
+          reducer=onmt.utils.ConcatReducer(),
+          cell_class=tf.contrib.rnn.LSTMCell,
+          dropout=0.3,
+          residual_connections=False),
+      decoder=onmt.decoders.AttentionalRNNDecoder(
+          num_layers=4,
+          num_units=512,
+          bridge=onmt.utils.CopyBridge(),
+          attention_mechanism_class=tf.contrib.seq2seq.LuongAttention,
+          cell_class=tf.contrib.rnn.LSTMCell,
+          dropout=0.3,
+          residual_connections=False))

--- a/config/models/transformer_fp16.py
+++ b/config/models/transformer_fp16.py
@@ -1,0 +1,22 @@
+"""Defines a Transformer model with experimental FP16 data type."""
+
+import tensorflow as tf
+import opennmt as onmt
+
+def model():
+  return onmt.models.Transformer(
+      source_inputter=onmt.inputters.WordEmbedder(
+          vocabulary_file_key="source_words_vocabulary",
+          embedding_size=512,
+          dtype=tf.float16),
+      target_inputter=onmt.inputters.WordEmbedder(
+          vocabulary_file_key="target_words_vocabulary",
+          embedding_size=512,
+          dtype=tf.float16),
+      num_layers=6,
+      num_units=512,
+      num_heads=8,
+      ffn_inner_dim=2048,
+      dropout=0.1,
+      attention_dropout=0.1,
+      relu_dropout=0.1)

--- a/opennmt/decoders/decoder.py
+++ b/opennmt/decoders/decoder.py
@@ -136,7 +136,8 @@ class Decoder(object):
                      maximum_iterations=250,
                      mode=tf.estimator.ModeKeys.PREDICT,
                      memory=None,
-                     memory_sequence_length=None):
+                     memory_sequence_length=None,
+                     dtype=None):
     """Decodes dynamically from :obj:`start_tokens` with greedy search.
 
     Usually used for inference.
@@ -151,6 +152,7 @@ class Decoder(object):
       mode: A ``tf.estimator.ModeKeys`` mode.
       memory: (optional) Memory values to query.
       memory_sequence_length: (optional) Memory values length.
+      dtype: The data type. Required if :obj:`memory` is ``None``.
 
     Returns:
       A tuple ``(predicted_ids, state, sequence_length, log_probs)``.
@@ -169,7 +171,8 @@ class Decoder(object):
                                 maximum_iterations=250,
                                 mode=tf.estimator.ModeKeys.PREDICT,
                                 memory=None,
-                                memory_sequence_length=None):
+                                memory_sequence_length=None,
+                                dtype=None):
     """Decodes dynamically from :obj:`start_tokens` with beam search.
 
     Usually used for inference.
@@ -186,6 +189,7 @@ class Decoder(object):
       mode: A ``tf.estimator.ModeKeys`` mode.
       memory: (optional) Memory values to query.
       memory_sequence_length: (optional) Memory values length.
+      dtype: The data type. Required if :obj:`memory` is ``None``.
 
     Returns:
       A tuple ``(predicted_ids, state, sequence_length, log_probs)``.

--- a/opennmt/decoders/self_attention_decoder.py
+++ b/opennmt/decoders/self_attention_decoder.py
@@ -224,7 +224,8 @@ class SelfAttentionDecoder(Decoder):
                      maximum_iterations=250,
                      mode=tf.estimator.ModeKeys.PREDICT,
                      memory=None,
-                     memory_sequence_length=None):
+                     memory_sequence_length=None,
+                     dtype=None):
     batch_size = tf.shape(start_tokens)[0]
     finished = tf.tile([False], [batch_size])
     step = tf.constant(0)
@@ -299,7 +300,8 @@ class SelfAttentionDecoder(Decoder):
                                 maximum_iterations=250,
                                 mode=tf.estimator.ModeKeys.PREDICT,
                                 memory=None,
-                                memory_sequence_length=None):
+                                memory_sequence_length=None,
+                                dtype=None):
     cache = self._init_cache(memory, memory_sequence_length=memory_sequence_length)
     symbols_to_logits_fn = self._symbols_to_logits_fn(embedding, vocab_size, mode)
 

--- a/opennmt/encoders/rnn_encoder.py
+++ b/opennmt/encoders/rnn_encoder.py
@@ -75,7 +75,7 @@ class UnidirectionalRNNEncoder(RNNEncoder):
         cell,
         inputs,
         sequence_length=sequence_length,
-        dtype=tf.float32)
+        dtype=inputs.dtype)
 
     return (encoder_outputs, encoder_state, sequence_length)
 
@@ -130,7 +130,7 @@ class BidirectionalRNNEncoder(RNNEncoder):
         cell_bw,
         inputs,
         sequence_length=sequence_length,
-        dtype=tf.float32)
+        dtype=inputs.dtype)
 
     # Merge bidirectional outputs and state.
     encoder_outputs = self.reducer.zip_and_reduce(encoder_outputs_tup[0], encoder_outputs_tup[1])

--- a/opennmt/inputters/inputter.py
+++ b/opennmt/inputters/inputter.py
@@ -13,10 +13,11 @@ from opennmt.utils.misc import extract_prefixed_keys
 class Inputter(object):
   """Base class for inputters."""
 
-  def __init__(self):
+  def __init__(self, dtype=tf.float32):
     self.padded_shapes = {}
     self.volatile = set()
     self.process_hooks = []
+    self.dtype = dtype
 
   def add_process_hooks(self, hooks):
     """Adds processing hooks.
@@ -215,7 +216,13 @@ class MultiInputter(Inputter):
   """An inputter that gathers multiple inputters."""
 
   def __init__(self, inputters):
-    super(MultiInputter, self).__init__()
+    if not isinstance(inputters, list) or not inputters:
+      raise ValueError("inputters must be a non empty list")
+    dtype = inputters[0].dtype
+    for inputter in inputters:
+      if inputter.dtype != dtype:
+        raise TypeError("All inputters must have the same dtype")
+    super(MultiInputter, self).__init__(dtype=dtype)
     self.inputters = inputters
 
   @abc.abstractmethod

--- a/opennmt/inputters/record_inputter.py
+++ b/opennmt/inputters/record_inputter.py
@@ -11,19 +11,20 @@ class SequenceRecordInputter(Inputter):
   Each record contains the following fields:
 
    * ``shape``: the shape of the tensor as a ``int64`` list.
-   * ``values``: the flattened tensor values as a ``float32`` list.
+   * ``values``: the flattened tensor values as a :obj:`dtype` list.
 
   Tensors are expected to be of shape ``[time, depth]``.
   """
 
-  def __init__(self, input_depth_key):
+  def __init__(self, input_depth_key, dtype=tf.float32):
     """Initializes the parameters of the record inputter.
 
     Args:
       input_depth_key: The data configuration key of the input depth value
         which has to be known statically.
+      dtype: The values type.
     """
-    super(SequenceRecordInputter, self).__init__()
+    super(SequenceRecordInputter, self).__init__(dtype=dtype)
     self.input_depth_key = input_depth_key
 
   def initialize(self, metadata):
@@ -37,7 +38,7 @@ class SequenceRecordInputter(Inputter):
 
   def _get_serving_input(self):
     receiver_tensors = {
-        "tensor": tf.placeholder(tf.float32, shape=(None, None, self.input_depth)),
+        "tensor": tf.placeholder(self.dtype, shape=(None, None, self.input_depth)),
         "length": tf.placeholder(tf.int32, shape=(None,))
     }
 
@@ -49,7 +50,7 @@ class SequenceRecordInputter(Inputter):
     if "tensor" not in data:
       features = tf.parse_single_example(data["raw"], features={
           "shape": tf.VarLenFeature(tf.int64),
-          "values": tf.VarLenFeature(tf.float32)
+          "values": tf.VarLenFeature(self.dtype)
       })
 
       values = features["values"].values

--- a/opennmt/models/model.py
+++ b/opennmt/models/model.py
@@ -39,8 +39,9 @@ def filter_irregular_batches(multiple):
 class Model(object):
   """Base class for models."""
 
-  def __init__(self, name):
+  def __init__(self, name, dtype=tf.float32):
     self.name = name
+    self.dtype = dtype
 
   def model_fn(self, num_devices=1):
     """Returns the model function.
@@ -142,7 +143,8 @@ class Model(object):
     """
     param_init = params.get("param_init")
     if param_init is not None:
-      return tf.random_uniform_initializer(minval=-param_init, maxval=param_init)
+      return tf.random_uniform_initializer(
+          minval=-param_init, maxval=param_init, dtype=self.dtype)
     return None
 
   @abc.abstractmethod

--- a/opennmt/models/sequence_classifier.py
+++ b/opennmt/models/sequence_classifier.py
@@ -31,7 +31,7 @@ class SequenceClassifier(Model):
     Raises:
       ValueError: if :obj:`encoding` is invalid.
     """
-    super(SequenceClassifier, self).__init__(name)
+    super(SequenceClassifier, self).__init__(name, dtype=inputter.dtype)
 
     self.inputter = inputter
     self.encoder = encoder

--- a/opennmt/models/sequence_tagger.py
+++ b/opennmt/models/sequence_tagger.py
@@ -32,7 +32,7 @@ class SequenceTagger(Model):
       crf_decoding: If ``True``, add a CRF layer after the encoder.
       name: The name of this model.
     """
-    super(SequenceTagger, self).__init__(name)
+    super(SequenceTagger, self).__init__(name, dtype=inputter.dtype)
 
     self.encoder = encoder
     self.inputter = inputter

--- a/opennmt/models/transformer.py
+++ b/opennmt/models/transformer.py
@@ -72,4 +72,5 @@ class Transformer(SequenceToSequence):
         name=name)
 
   def _initializer(self, params):
-    return tf.variance_scaling_initializer(mode="fan_avg", distribution="uniform")
+    return tf.variance_scaling_initializer(
+        mode="fan_avg", distribution="uniform", dtype=self.dtype)

--- a/opennmt/utils/losses.py
+++ b/opennmt/utils/losses.py
@@ -4,12 +4,14 @@ import tensorflow as tf
 
 
 def _smooth_one_hot_labels(logits, labels, label_smoothing):
+  label_smoothing = tf.constant(label_smoothing, dtype=logits.dtype)
   num_classes = tf.shape(logits)[-1]
   return tf.one_hot(
       tf.cast(labels, tf.int32),
       num_classes,
       on_value=1.0 - label_smoothing,
-      off_value=label_smoothing / tf.to_float(num_classes - 1))
+      off_value=label_smoothing / tf.cast(num_classes - 1, label_smoothing.dtype),
+      dtype=logits.dtype)
 
 def _softmax_cross_entropy(logits, labels, label_smoothing, mode):
   if mode == tf.estimator.ModeKeys.TRAIN and label_smoothing > 0.0:


### PR DESCRIPTION
This makes all operations using the dtype defined by the inputter and allows using, e.g., FP16 models.

Related to #57.