### PR TITLE
Allow split training end evaluation runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ python -m bin.build_vocab --size 50000 --save_vocab data/toy-ende/tgt-vocab.txt 
 2\. Train with preset parameters:
 
 ```
-python -m bin.main train --model config/models/nmt_small.py --config config/opennmt-defaults.yml config/data/toy-ende.yml
+python -m bin.main train_and_eval --model config/models/nmt_small.py --config config/opennmt-defaults.yml config/data/toy-ende.yml
 ```
 
 3\. Translate a test file with the latest checkpoint:

--- a/bin/main.py
+++ b/bin/main.py
@@ -35,7 +35,7 @@ def _prefix_paths(prefix, paths):
 
 def main():
   parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-  parser.add_argument("run", choices=["train", "infer", "export"],
+  parser.add_argument("run", choices=["train_and_eval", "infer", "export"],
                       help="Run type.")
   parser.add_argument("--config", required=True, nargs="+",
                       help="List of configuration files.")
@@ -112,8 +112,8 @@ def main():
       num_devices=args.num_gpus,
       gpu_allow_growth=args.gpu_allow_growth)
 
-  if args.run == "train":
-    runner.train()
+  if args.run == "train_and_eval":
+    runner.train_and_evaluate()
   elif args.run == "infer":
     if not args.features_file:
       parser.error("--features_file is required for inference.")

--- a/bin/main.py
+++ b/bin/main.py
@@ -35,7 +35,7 @@ def _prefix_paths(prefix, paths):
 
 def main():
   parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-  parser.add_argument("run", choices=["train_and_eval", "infer", "export"],
+  parser.add_argument("run", choices=["train_and_eval", "train", "infer", "export"],
                       help="Run type.")
   parser.add_argument("--config", required=True, nargs="+",
                       help="List of configuration files.")
@@ -114,6 +114,8 @@ def main():
 
   if args.run == "train_and_eval":
     runner.train_and_evaluate()
+  elif args.run == "train":
+    runner.train()
   elif args.run == "infer":
     if not args.features_file:
       parser.error("--features_file is required for inference.")

--- a/bin/main.py
+++ b/bin/main.py
@@ -35,7 +35,7 @@ def _prefix_paths(prefix, paths):
 
 def main():
   parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-  parser.add_argument("run", choices=["train_and_eval", "train", "infer", "export"],
+  parser.add_argument("run", choices=["train_and_eval", "train", "eval", "infer", "export"],
                       help="Run type.")
   parser.add_argument("--config", required=True, nargs="+",
                       help="List of configuration files.")
@@ -116,6 +116,8 @@ def main():
     runner.train_and_evaluate()
   elif args.run == "train":
     runner.train()
+  elif args.run == "eval":
+    runner.evaluate(checkpoint_path=args.checkpoint_path)
   elif args.run == "infer":
     if not args.features_file:
       parser.error("--features_file is required for inference.")

--- a/config/sample.yml
+++ b/config/sample.yml
@@ -93,7 +93,7 @@ train:
 
 # (optional) Evaluation options.
 eval:
-  # (optional) The batch size to use (default: train value or 30 if not applicable).
+  # (optional) The batch size to use (default: 32).
   batch_size: 30
   # (optional) The number of threads to use for processing data in parallel (default: 1).
   num_threads: 1

--- a/config/sample.yml
+++ b/config/sample.yml
@@ -6,8 +6,11 @@
 model_dir: toy-ende
 
 data:
+  # (required for train_and_eval and train run types).
   train_features_file: data/toy-ende/src-train.txt
   train_labels_file: data/toy-ende/tgt-train.txt
+
+  # (required for train_end_eval and eval run types).
   eval_features_file: data/toy-ende/src-val.txt
   eval_labels_file: data/toy-ende/tgt-val.txt
 

--- a/opennmt/runner.py
+++ b/opennmt/runner.py
@@ -66,8 +66,8 @@ class Runner(object):
         config=run_config,
         params=self._config["params"])
 
-  def train(self):
-    """Runs training."""
+  def train_and_evaluate(self):
+    """Runs training and evaluation loop."""
     if "eval" not in self._config:
       self._config["eval"] = {}
 

--- a/opennmt/runner.py
+++ b/opennmt/runner.py
@@ -147,6 +147,14 @@ class Runner(object):
     self._estimator.train(
         train_spec.input_fn, hooks=train_spec.hooks, max_steps=train_spec.max_steps)
 
+  def evaluate(self, checkpoint_path=None):
+    """Runs training loop."""
+    if checkpoint_path is not None and os.path.isdir(checkpoint_path):
+      checkpoint_path = tf.train.latest_checkpoint(checkpoint_path)
+    eval_spec = self._build_eval_spec()
+    self._estimator.evaluate(
+        eval_spec.input_fn, hooks=eval_spec.hooks, checkpoint_path=checkpoint_path)
+
   def infer(self, features_file, predictions_file=None, checkpoint_path=None):
     """Runs inference.
 

--- a/opennmt/runner.py
+++ b/opennmt/runner.py
@@ -66,16 +66,45 @@ class Runner(object):
         config=run_config,
         params=self._config["params"])
 
-  def train_and_evaluate(self):
-    """Runs training and evaluation loop."""
-    if "eval" not in self._config:
-      self._config["eval"] = {}
-
+  def _build_train_spec(self):
     train_hooks = [
         hooks.LogParametersCountHook(),
         hooks.CountersHook(
             every_n_steps=self._estimator.config.save_summary_steps,
             output_dir=self._estimator.model_dir)]
+
+    default_sample_buffer_size = 1000000
+    if "sample_buffer_size" not in self._config["train"]:
+      tf.logging.warn("You did not set sample_buffer_size. By default, the "
+                      "training dataset is shuffled by chunk of %d examples. "
+                      "If your dataset is larger than this value and eval_delay "
+                      "is shorter than the training time of one epoch, a section "
+                      "of the dataset will be discarded. Consider setting "
+                      "sample_buffer_size to the size of your dataset."
+                      % default_sample_buffer_size)
+
+    train_spec = tf.estimator.TrainSpec(
+        input_fn=self._model.input_fn(
+            tf.estimator.ModeKeys.TRAIN,
+            self._config["train"]["batch_size"],
+            self._config["data"],
+            self._config["data"]["train_features_file"],
+            labels_file=self._config["data"]["train_labels_file"],
+            batch_type=self._config["train"].get("batch_type", "examples"),
+            batch_multiplier=self._num_devices,
+            bucket_width=self._config["train"].get("bucket_width", 5),
+            num_threads=self._config["train"].get("num_threads"),
+            sample_buffer_size=self._config["train"].get(
+                "sample_buffer_size", default_sample_buffer_size),
+            maximum_features_length=self._config["train"].get("maximum_features_length"),
+            maximum_labels_length=self._config["train"].get("maximum_labels_length")),
+        max_steps=self._config["train"].get("train_steps"),
+        hooks=train_hooks)
+    return train_spec
+
+  def _build_eval_spec(self):
+    if "eval" not in self._config:
+      self._config["eval"] = {}
 
     eval_hooks = []
     if (self._config["eval"].get("save_eval_predictions", False)
@@ -91,42 +120,10 @@ class Runner(object):
               self._config["data"]["eval_labels_file"],
               output_dir=self._estimator.model_dir)))
 
-    default_sample_buffer_size = 1000000
-    if "sample_buffer_size" not in self._config["train"]:
-      tf.logging.warn("You did not set sample_buffer_size. By default, the "
-                      "training dataset is shuffled by chunk of %d examples. "
-                      "If your dataset is larger than this value and eval_delay "
-                      "is shorter than the training time of one epoch, a section "
-                      "of the dataset will be discarded. Consider setting "
-                      "sample_buffer_size to the size of your dataset."
-                      % default_sample_buffer_size)
-
-    train_batch_size = self._config["train"]["batch_size"]
-    train_batch_type = self._config["train"].get("batch_type", "examples")
-    train_spec = tf.estimator.TrainSpec(
-        input_fn=self._model.input_fn(
-            tf.estimator.ModeKeys.TRAIN,
-            train_batch_size,
-            self._config["data"],
-            self._config["data"]["train_features_file"],
-            labels_file=self._config["data"]["train_labels_file"],
-            batch_type=train_batch_type,
-            batch_multiplier=self._num_devices,
-            bucket_width=self._config["train"].get("bucket_width", 5),
-            num_threads=self._config["train"].get("num_threads"),
-            sample_buffer_size=self._config["train"].get(
-                "sample_buffer_size", default_sample_buffer_size),
-            maximum_features_length=self._config["train"].get("maximum_features_length"),
-            maximum_labels_length=self._config["train"].get("maximum_labels_length")),
-        max_steps=self._config["train"].get("train_steps"),
-        hooks=train_hooks)
-
-    eval_batch_size = self._config["eval"].get(
-        "batch_size", train_batch_size if train_batch_type == "examples" else 30)
     eval_spec = tf.estimator.EvalSpec(
         input_fn=self._model.input_fn(
             tf.estimator.ModeKeys.EVAL,
-            eval_batch_size,
+            self._config["eval"].get("batch_size", 32),
             self._config["data"],
             self._config["data"]["eval_features_file"],
             num_threads=self._config["eval"].get("num_threads"),
@@ -136,8 +133,19 @@ class Runner(object):
         exporters=tf.estimator.LatestExporter(
             "latest", self._model.serving_input_fn(self._config["data"])),
         throttle_secs=self._config["eval"].get("eval_delay", 18000))
+    return eval_spec
 
+  def train_and_evaluate(self):
+    """Runs training and evaluation loop."""
+    train_spec = self._build_train_spec()
+    eval_spec = self._build_eval_spec()
     tf.estimator.train_and_evaluate(self._estimator, train_spec, eval_spec)
+
+  def train(self):
+    """Runs training loop."""
+    train_spec = self._build_train_spec()
+    self._estimator.train(
+        train_spec.input_fn, hooks=train_spec.hooks, max_steps=train_spec.max_steps)
 
   def infer(self, features_file, predictions_file=None, checkpoint_path=None):
     """Runs inference.


### PR DESCRIPTION
This PR adds 2 run types:

* `train`: runs the training
* `eval`: runs the evaluation

The current `train` behavior is now `train_and_eval` for clarity.