### PR TITLE
Infer records depth dimension by peeking the records file

### DIFF
--- a/config/models/listen_attend_spell.py
+++ b/config/models/listen_attend_spell.py
@@ -7,8 +7,7 @@ import opennmt as onmt
 
 def model():
   return onmt.models.SequenceToSequence(
-      source_inputter=onmt.inputters.SequenceRecordInputter(
-          input_depth_key="input_depth"),
+      source_inputter=onmt.inputters.SequenceRecordInputter(),
       target_inputter=onmt.inputters.WordEmbedder(
           vocabulary_file_key="target_vocabulary",
           embedding_size=50),


### PR DESCRIPTION
This makes training on record files more convenient as there is now no need to specify the depth dimension in the configuration file.