### PR TITLE
Disable the daisy chain custom getter for non Transformer models

### DIFF
--- a/opennmt/models/model.py
+++ b/opennmt/models/model.py
@@ -18,8 +18,9 @@ from opennmt.utils.parallel import GraphDispatcher
 class Model(object):
   """Base class for models."""
 
-  def __init__(self, name, dtype=tf.float32):
+  def __init__(self, name, daisy_chain_variables=False, dtype=tf.float32):
     self.name = name
+    self.daisy_chain_variables = daisy_chain_variables
     self.dtype = dtype
 
   def model_fn(self, num_devices=1):
@@ -32,7 +33,8 @@ class Model(object):
       ``tf.estimator.Estimator`` 's ``model_fn`` argument for more details about
       arguments and the returned value.
     """
-    dispatcher = GraphDispatcher(num_devices)
+    dispatcher = GraphDispatcher(
+        num_devices, daisy_chain_variables=self.daisy_chain_variables)
 
     def _loss_op(features, labels, params, mode, config):
       """Single callable to compute the loss."""

--- a/opennmt/models/sequence_classifier.py
+++ b/opennmt/models/sequence_classifier.py
@@ -15,6 +15,7 @@ class SequenceClassifier(Model):
                encoder,
                labels_vocabulary_file_key,
                encoding="average",
+               daisy_chain_variables=False,
                name="seqclassifier"):
     """Initializes a sequence classifier.
 
@@ -26,12 +27,15 @@ class SequenceClassifier(Model):
         vocabulary file containing one label per line.
       encoding: "average" or "last" (case insensitive), the encoding vector to
         extract from the encoder outputs.
+      daisy_chain_variables: If ``True``, copy variables in a daisy chain
+        between devices for this model. Not compatible with RNN based models.
       name: The name of this model.
 
     Raises:
       ValueError: if :obj:`encoding` is invalid.
     """
-    super(SequenceClassifier, self).__init__(name, dtype=inputter.dtype)
+    super(SequenceClassifier, self).__init__(
+        name, daisy_chain_variables=daisy_chain_variables, dtype=inputter.dtype)
 
     self.inputter = inputter
     self.encoder = encoder

--- a/opennmt/models/sequence_tagger.py
+++ b/opennmt/models/sequence_tagger.py
@@ -17,6 +17,7 @@ class SequenceTagger(Model):
                labels_vocabulary_file_key,
                tagging_scheme=None,
                crf_decoding=False,
+               daisy_chain_variables=False,
                name="seqtagger"):
     """Initializes a sequence tagger.
 
@@ -30,9 +31,12 @@ class SequenceTagger(Model):
         only BIOES), additional evaluation metrics could be computed such as
         precision, recall, etc.
       crf_decoding: If ``True``, add a CRF layer after the encoder.
+      daisy_chain_variables: If ``True``, copy variables in a daisy chain
+        between devices for this model. Not compatible with RNN based models.
       name: The name of this model.
     """
-    super(SequenceTagger, self).__init__(name, dtype=inputter.dtype)
+    super(SequenceTagger, self).__init__(
+        name, daisy_chain_variables=daisy_chain_variables, dtype=inputter.dtype)
 
     self.encoder = encoder
     self.inputter = inputter

--- a/opennmt/models/sequence_to_sequence.py
+++ b/opennmt/models/sequence_to_sequence.py
@@ -60,6 +60,7 @@ class SequenceToSequence(Model):
                target_inputter,
                encoder,
                decoder,
+               daisy_chain_variables=False,
                name="seq2seq"):
     """Initializes a sequence-to-sequence model.
 
@@ -71,6 +72,8 @@ class SequenceToSequence(Model):
         :class:`opennmt.inputters.text_inputter.WordEmbedder` is supported.
       encoder: A :class:`opennmt.encoders.encoder.Encoder` to encode the source.
       decoder: A :class:`opennmt.decoders.decoder.Decoder` to decode the target.
+      daisy_chain_variables: If ``True``, copy variables in a daisy chain
+        between devices for this model. Not compatible with RNN based models.
       name: The name of this model.
 
     Raises:
@@ -84,7 +87,8 @@ class SequenceToSequence(Model):
           "Source and target inputters must have the same dtype, "
           "saw: {} and {}".format(source_inputter.dtype, target_inputter.dtype))
 
-    super(SequenceToSequence, self).__init__(name, dtype=source_inputter.dtype)
+    super(SequenceToSequence, self).__init__(
+        name, daisy_chain_variables=daisy_chain_variables, dtype=source_inputter.dtype)
 
     if not isinstance(target_inputter, inputters.WordEmbedder):
       raise TypeError("Target inputter must be a WordEmbedder")

--- a/opennmt/models/transformer.py
+++ b/opennmt/models/transformer.py
@@ -69,6 +69,7 @@ class Transformer(SequenceToSequence):
         target_inputter,
         encoder,
         decoder,
+        daisy_chain_variables=True,
         name=name)
 
   def _initializer(self, params):


### PR DESCRIPTION
Models containing dynamic loops (e.g. RNNs) are not compatible with this custom variable getter so disable it by default for models where RNNs can be used (currently all except the Transformer).

Closes #74.