### PR TITLE
Update minimum required TensorFlow version to 1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ OpenNMT-tf follows [semantic versioning 2.0.0](https://semver.org/). The API cov
 
 ## [Unreleased]
 
+### Breaking changes
+
+* Update minimum required TensorFlow version from 1.4 to 1.6
+
 ## [1.0.0](https://github.com/OpenNMT/OpenNMT-tf/releases/tag/1.0.0) (2018-03-14)
 
 Initial stable release.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ OpenNMT-tf is also compatible with some of the best TensorFlow features:
 
 ## Requirements
 
-* `tensorflow` (`1.4`)
+* `tensorflow` (`1.6`)
 * `pyyaml`
 
 ## Overview

--- a/examples/cpp/README.md
+++ b/examples/cpp/README.md
@@ -18,7 +18,7 @@ This example shows how to translate a batch of sentences using the TensorFlow C+
 ```
 git clone https://github.com/tensorflow/tensorflow.git ~/tensorflow
 cd ~/tensorflow
-git checkout r1.4
+git checkout r1.6
 ```
 
 3\. Add a custom compilation target at the end of `tensorflow/BUILD`:

--- a/examples/serving/README.md
+++ b/examples/serving/README.md
@@ -4,7 +4,7 @@ This example implements a simple client that sends translation requests to a mod
 
 ### Requirements
 
-* [TensorFlow Serving](https://www.tensorflow.org/serving) (`1.4`)
+* [TensorFlow Serving](https://www.tensorflow.org/serving)
 * an exported translation model
 
 **Note:** for this example to work, the model should be a `SequenceToSequence` model with `WordEmbedder` as the source inputter.
@@ -48,4 +48,4 @@ In particular, the provided configuration makes the server run a batch translati
 
 This explains why running the command above, the first 2 translations were received immediately (`max_batch_size` reached) and the third came 5 seconds later (`batch_timeout_micros` reached).
 
-For more information, see the [TensorFlow Serving Batching Guide](https://github.com/tensorflow/serving/tree/r1.4/tensorflow_serving/batching).
+For more information, see the [TensorFlow Serving Batching Guide](https://github.com/tensorflow/serving/tree/r1.6/tensorflow_serving/batching).

--- a/opennmt/decoders/rnn_decoder.py
+++ b/opennmt/decoders/rnn_decoder.py
@@ -245,7 +245,7 @@ def _build_attention_mechanism(attention_mechanism,
   """Builds an attention mechanism from a class or a callable."""
   if inspect.isclass(attention_mechanism):
     return attention_mechanism(
-        num_units, memory, memory_sequence_length=memory_sequence_length)
+        num_units, memory, memory_sequence_length=memory_sequence_length, dtype=memory.dtype)
   elif callable(attention_mechanism):
     return attention_mechanism(
         num_units, memory, memory_sequence_length)

--- a/opennmt/models/model.py
+++ b/opennmt/models/model.py
@@ -328,12 +328,7 @@ class Model(object):
     if prefetch_buffer_size:
       dataset = dataset.prefetch(prefetch_buffer_size)
 
-    iterator = dataset.make_initializable_iterator()
-
-    # Add the initializer to a standard collection for it to be initialized.
-    tf.add_to_collection(tf.GraphKeys.TABLE_INITIALIZERS, iterator.initializer)
-
-    return iterator.get_next()
+    return dataset
 
   def input_fn(self,
                mode,
@@ -350,7 +345,7 @@ class Model(object):
                prefetch_buffer_size=None,
                maximum_features_length=None,
                maximum_labels_length=None):
-    """Returns an input function.
+    """Returns an input pipeline.
 
     Args:
       mode: A ``tf.estimator.ModeKeys`` mode.
@@ -375,7 +370,7 @@ class Model(object):
         ``None`` to not constrain the length.
 
     Returns:
-      A callable that returns the next element.
+      A ``tf.data.Dataset``.
 
     Raises:
       ValueError: if :obj:`labels_file` is not set when in training or

--- a/opennmt/runner.py
+++ b/opennmt/runner.py
@@ -201,4 +201,5 @@ class Runner(object):
     self._estimator.export_savedmodel(
         os.path.join(export_dir, "manual"),
         self._model.serving_input_fn(self._config["data"]),
-        checkpoint_path=checkpoint_path)
+        checkpoint_path=checkpoint_path,
+        strip_default_attrs=True)

--- a/opennmt/utils/beam_search.py
+++ b/opennmt/utils/beam_search.py
@@ -108,7 +108,7 @@ def get_state_shape_invariants(tensor):
 
 
 def _log_prob_from_logits(logits):
-  return logits - tf.reduce_logsumexp(logits, axis=2, keep_dims=True)
+  return logits - tf.reduce_logsumexp(logits, axis=2, keepdims=True)
 
 
 def compute_batch_indices(batch_size, beam_size):

--- a/opennmt/utils/losses.py
+++ b/opennmt/utils/losses.py
@@ -16,7 +16,7 @@ def _smooth_one_hot_labels(logits, labels, label_smoothing):
 def _softmax_cross_entropy(logits, labels, label_smoothing, mode):
   if mode == tf.estimator.ModeKeys.TRAIN and label_smoothing > 0.0:
     smoothed_labels = _smooth_one_hot_labels(logits, labels, label_smoothing)
-    return tf.nn.softmax_cross_entropy_with_logits(
+    return tf.nn.softmax_cross_entropy_with_logits_v2(
         logits=logits, labels=smoothed_labels)
   else:
     return tf.nn.sparse_softmax_cross_entropy_with_logits(

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@ setup(
         "pyyaml"
     ],
     extras_require={
-        "TensorFlow": ["tensorflow==1.4.0"],
-        "TensorFlow (with CUDA support)": ["tensorflow-gpu==1.4.0"]
+        "TensorFlow": ["tensorflow==1.6.0"],
+        "TensorFlow (with CUDA support)": ["tensorflow-gpu==1.6.0"]
     },
     tests_require=[
         "nose2"


### PR DESCRIPTION
For compatibility with TensorFlow 1.4 (last version compiled against CUDA 8), you can stay on the `r1` branch.