### PR TITLE
Fix JoinReducer to not unpack named tuples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ OpenNMT-tf follows [semantic versioning 2.0.0](https://semver.org/). The API cov
 
 * Update minimum required TensorFlow version from 1.4 to 1.6
 
+### Fixes and improvements
+
+* Fix the encoder state structure when RNN encoders are combined (e.g. in `SequentialEncoder`)
+
 ## [1.0.1](https://github.com/OpenNMT/OpenNMT-tf/releases/tag/v1.0.1) (2018-03-14)
 
 ### Fixes and improvements

--- a/opennmt/encoders/rnn_encoder.py
+++ b/opennmt/encoders/rnn_encoder.py
@@ -184,7 +184,7 @@ class GoogleRNNEncoder(Encoder):
         sequence_length=sequence_length,
         mode=mode)
 
-    encoder_state = bidirectional_state + unidirectional_state
+    encoder_state = JoinReducer().reduce([bidirectional_state, unidirectional_state])
 
     return (encoder_outputs, encoder_state, sequence_length)
 

--- a/opennmt/layers/reducer.py
+++ b/opennmt/layers/reducer.py
@@ -194,13 +194,14 @@ class JoinReducer(Reducer):
   """A reducer that joins its inputs in a single tuple."""
 
   def reduce(self, inputs):
-    output = ()
+    output = []
     for elem in inputs:
-      if isinstance(elem, tuple):
-        output += elem
+      if isinstance(elem, tuple) and not hasattr(elem, "_fields"):
+        for e in elem:
+          output.append(e)
       else:
-        output += (elem,)
-    return output
+        output.append(elem)
+    return tuple(output)
 
   def reduce_sequence(self, inputs, sequence_lengths):
     raise NotImplementedError("JoinReducer does not support sequence reduction")

--- a/opennmt/tests/reducer_test.py
+++ b/opennmt/tests/reducer_test.py
@@ -1,3 +1,5 @@
+import collections
+
 import tensorflow as tf
 
 from opennmt.layers import reducer
@@ -154,6 +156,17 @@ class ReducerTest(tf.test.TestCase):
       reduced, length = sess.run([reduced, length])
       self.assertAllEqual(expected, reduced)
       self.assertAllEqual([5, 5, 4], length)
+
+  def testJoinReducer(self):
+    self.assertTupleEqual((1, 2, 3), reducer.JoinReducer().reduce([1, 2, 3]))
+    self.assertTupleEqual((1, 2, 3), reducer.JoinReducer().reduce([(1,), (2,), (3,)]))
+    self.assertTupleEqual((1, 2, 3), reducer.JoinReducer().reduce([1, (2, 3)]))
+
+    # Named tuples should not be unpacked.
+    State = collections.namedtuple("State", ["h", "c"])
+    self.assertTupleEqual((State(h=1, c=2), State(h=3, c=4), State(h=5, c=6)),
+                          reducer.JoinReducer().reduce([
+                              State(h=1, c=2), (State(h=3, c=4), State(h=5, c=6))]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This makes the `CopyBridge` operator compatible with combined RNN encoders that appeared to be valid candidates for this bridge (e.g. `GoogleRNNEncoder` with the same number of layers and depth
as the decoder).