### PR TITLE
Relax TensorFlow version requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,22 @@
 language: python
 python:
   - "2.7"
-  - "3.4"
-  - "3.5"
   - "3.6"
 env:
   global:
     - MAIN_PYTHON_VERSION="2.7"
     - MAIN_TF_VERSION="1.6.*"
   matrix:
+    - TF_VERSION="1.4.*"
+    - TF_VERSION="1.5.*"
     - TF_VERSION="1.6.*"
     - TF_VERSION="1.7.*"
+matrix:
+  exclude:
+    - python: "3.6"
+      env: TF_VERSION="1.4.*"
+    - python: "3.6"
+      env: TF_VERSION="1.5.*"
 addons:
   apt:
     sources:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ OpenNMT-tf follows [semantic versioning 2.0.0](https://semver.org/). The API cov
 
 ### Fixes and improvements
 
+* Fix error when using FP16 and an `AttentionMechanism` module (for TensorFlow 1.5+)
+* Manual export will remove default-valued attributes from the NodeDefs (for TensorFlow 1.6+)
+* Silence some deprecation warnings with recent TensorFlow versions
+
 ## [1.0.3](https://github.com/OpenNMT/OpenNMT-tf/releases/tag/v1.0.3) (2018-04-02)
 
 ### Fixes and improvements
@@ -43,5 +47,3 @@ OpenNMT-tf follows [semantic versioning 2.0.0](https://semver.org/). The API cov
 ## [1.0.0](https://github.com/OpenNMT/OpenNMT-tf/releases/tag/v1.0.0) (2018-03-14)
 
 Initial stable release.
-
-This is the latest major release compatible with TensorFlow 1.4.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ OpenNMT-tf follows [semantic versioning 2.0.0](https://semver.org/). The API cov
 
 ### Breaking changes
 
-* Update minimum required TensorFlow version from 1.4 to 1.6
+### New features
 
 ### Fixes and improvements
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ OpenNMT-tf is also compatible with some of the best TensorFlow features:
 
 ## Requirements
 
-* `tensorflow` (>= 1.6)
+* `tensorflow` (>= 1.4)
 
 ## Installation
 

--- a/examples/serving/README.md
+++ b/examples/serving/README.md
@@ -48,4 +48,4 @@ In particular, the provided configuration makes the server run a batch translati
 
 This explains why running the command above, the first 2 translations were received immediately (`max_batch_size` reached) and the third came 5 seconds later (`batch_timeout_micros` reached).
 
-For more information, see the [TensorFlow Serving Batching Guide](https://github.com/tensorflow/serving/tree/r1.6/tensorflow_serving/batching).
+For more information, see the [TensorFlow Serving Batching Guide](https://github.com/tensorflow/serving/tree/master/tensorflow_serving/batching).

--- a/opennmt/decoders/rnn_decoder.py
+++ b/opennmt/decoders/rnn_decoder.py
@@ -4,6 +4,8 @@ import inspect
 
 import tensorflow as tf
 
+from tensorflow.python.estimator.util import fn_args
+
 from opennmt.decoders.decoder import Decoder, logits_to_cum_log_probs, build_output_layer
 from opennmt.utils.cell import build_cell
 
@@ -244,8 +246,12 @@ def _build_attention_mechanism(attention_mechanism,
                                memory_sequence_length=None):
   """Builds an attention mechanism from a class or a callable."""
   if inspect.isclass(attention_mechanism):
+    kwargs = {}
+    if "dtype" in fn_args(attention_mechanism):
+      # For TensorFlow 1.5+, dtype should be set in the constructor.
+      kwargs["dtype"] = memory.dtype
     return attention_mechanism(
-        num_units, memory, memory_sequence_length=memory_sequence_length, dtype=memory.dtype)
+        num_units, memory, memory_sequence_length=memory_sequence_length, **kwargs)
   elif callable(attention_mechanism):
     return attention_mechanism(
         num_units, memory, memory_sequence_length)

--- a/opennmt/models/model.py
+++ b/opennmt/models/model.py
@@ -328,7 +328,12 @@ class Model(object):
     if prefetch_buffer_size:
       dataset = dataset.prefetch(prefetch_buffer_size)
 
-    return dataset
+    iterator = dataset.make_initializable_iterator()
+
+    # Add the initializer to a standard collection for it to be initialized.
+    tf.add_to_collection(tf.GraphKeys.TABLE_INITIALIZERS, iterator.initializer)
+
+    return iterator.get_next()
 
   def input_fn(self,
                mode,
@@ -345,7 +350,7 @@ class Model(object):
                prefetch_buffer_size=None,
                maximum_features_length=None,
                maximum_labels_length=None):
-    """Returns an input pipeline.
+    """Returns an input function.
 
     Args:
       mode: A ``tf.estimator.ModeKeys`` mode.
@@ -370,7 +375,7 @@ class Model(object):
         ``None`` to not constrain the length.
 
     Returns:
-      A ``tf.data.Dataset``.
+      A callable that returns the next element.
 
     Raises:
       ValueError: if :obj:`labels_file` is not set when in training or

--- a/opennmt/runner.py
+++ b/opennmt/runner.py
@@ -8,6 +8,8 @@ import random
 import numpy as np
 import tensorflow as tf
 
+from tensorflow.python.estimator.util import fn_args
+
 from opennmt.utils import hooks
 from opennmt.utils.evaluator import external_evaluation_fn
 
@@ -202,8 +204,14 @@ class Runner(object):
     if not os.path.isdir(export_dir):
       os.makedirs(export_dir)
 
+    kwargs = {}
+    if "strip_default_attrs" in fn_args(self._estimator.export_savedmodel):
+      # Set strip_default_attrs to True for TensorFlow 1.6+ to stay consistent
+      # with the behavior of tf.estimator.Exporter.
+      kwargs["strip_default_attrs"] = True
+
     return self._estimator.export_savedmodel(
         os.path.join(export_dir, "manual"),
         self._model.serving_input_fn(self._config["data"]),
         checkpoint_path=checkpoint_path,
-        strip_default_attrs=True)
+        **kwargs)

--- a/opennmt/utils/beam_search.py
+++ b/opennmt/utils/beam_search.py
@@ -25,6 +25,8 @@ import tensorflow as tf
 
 from tensorflow.python.util import nest
 
+from tensorflow.python.estimator.util import fn_args
+
 # Assuming EOS_ID is 1
 EOS_ID = 1
 # Default value for INF
@@ -108,7 +110,12 @@ def get_state_shape_invariants(tensor):
 
 
 def _log_prob_from_logits(logits):
-  return logits - tf.reduce_logsumexp(logits, axis=2, keepdims=True)
+  # Silence deprecation warning in TensorFlow 1.5+ by using the renamed argument.
+  if "keepdims" in fn_args(tf.reduce_logsumexp):
+    kwargs = {"keepdims": True}
+  else:
+    kwargs = {"keep_dims": True}
+  return logits - tf.reduce_logsumexp(logits, axis=2, **kwargs)
 
 
 def compute_batch_indices(batch_size, beam_size):

--- a/opennmt/utils/losses.py
+++ b/opennmt/utils/losses.py
@@ -16,7 +16,11 @@ def _smooth_one_hot_labels(logits, labels, label_smoothing):
 def _softmax_cross_entropy(logits, labels, label_smoothing, mode):
   if mode == tf.estimator.ModeKeys.TRAIN and label_smoothing > 0.0:
     smoothed_labels = _smooth_one_hot_labels(logits, labels, label_smoothing)
-    return tf.nn.softmax_cross_entropy_with_logits_v2(
+    if hasattr(tf.nn, "softmax_cross_entropy_with_logits_v2"):
+      cross_entropy_fn = tf.nn.softmax_cross_entropy_with_logits_v2
+    else:
+      cross_entropy_fn = tf.nn.softmax_cross_entropy_with_logits
+    return cross_entropy_fn(
         logits=logits, labels=smoothed_labels)
   else:
     return tf.nn.sparse_softmax_cross_entropy_with_logits(

--- a/setup.py
+++ b/setup.py
@@ -32,8 +32,8 @@ setup(
         "pyyaml"
     ],
     extras_require={
-        "tensorflow": ["tensorflow>=1.6.0"],
-        "tensorflow_gpu": ["tensorflow-gpu>=1.6.0"]
+        "tensorflow": ["tensorflow>=1.4.0"],
+        "tensorflow_gpu": ["tensorflow-gpu>=1.4.0"]
     },
     tests_require=[
         "nose2"


### PR DESCRIPTION
The code on `master` was using very few new features from the latest TensorFlow versions. So let's avoid breaking compatibility with 1.4 and 1.5 for now but still use newer arguments or functions when available.