### PR TITLE
Use latest pyonmttok package

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "third_party/OpenNMTTokenizer"]
-	path = third_party/OpenNMTTokenizer
-	url = https://github.com/OpenNMT/Tokenizer.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,21 +17,8 @@ matrix:
       env: TF_VERSION="1.4.*"
     - python: "3.6"
       env: TF_VERSION="1.5.*"
-addons:
-  apt:
-    sources:
-      - george-edison55-precise-backports
-      - ubuntu-toolchain-r-test
-    packages:
-      - gcc-4.8
-      - g++-4.8
-      - cmake
-      - cmake-data
-      - libboost-python-dev
 before_install:
   - pip install tensorflow==$TF_VERSION
-  - pip install pyyaml
-  - pip install nose2
   - |
         if [[ "$TRAVIS_PYTHON_VERSION" == "$MAIN_PYTHON_VERSION" && "$TF_VERSION" == "$MAIN_TF_VERSION" ]]; then
             pip install pylint==1.8.2
@@ -42,15 +29,8 @@ before_install:
             pip install wheel
             pip install twine
         fi
-install:
-  - export CXX="g++-4.8" CC="gcc-4.8"
-  - mkdir build && cd build
-  - cmake ..
-  - make
-  - export PYTHONPATH="$PYTHONPATH:$PWD/third_party/OpenNMTTokenizer/bindings/python/"
-  - cd ..
 script:
-  - nose2
+  - python setup.py test
   - if [ "$TRAVIS_PYTHON_VERSION" == "$MAIN_PYTHON_VERSION" && "$TF_VERSION" == "$MAIN_TF_VERSION" ]; then pylint opennmt/; fi
 after_success:
   - |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ OpenNMT-tf follows [semantic versioning 2.0.0](https://semver.org/). The API cov
 
 ### New features
 
+* Update the OpenNMT tokenizer to 1.3.0 and use its Python package instead of requiring a manual compilation (Linux only)
+
 ### Fixes and improvements
 
 * Fix error when using FP16 and an `AttentionMechanism` module (for TensorFlow 1.5+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,0 @@
-cmake_minimum_required(VERSION 3.1)
-
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_BUILD_TYPE Release)
-set(LIB_ONLY ON)
-set(WITH_PYTHON_BINDINGS ON)
-
-add_subdirectory(third_party/OpenNMTTokenizer)

--- a/config/tokenization/sample.yml
+++ b/config/tokenization/sample.yml
@@ -1,13 +1,40 @@
 # This is a sample tokenization configuration with all values set to their default.
 
+# Can be: conservative, aggressive, none.
+#  conservative: Allows mix of alphanumeric as in "2,000", "E65", "soft-landing".
+#  aggressive: Only keeps sequences of letters/numbers.
+#  none: Forwards the input text (possibly to the subtokenizer).
 mode: conservative
+
+# (optional) Path the BPE model.
 bpe_model_path: ""
+# (optional) Path the SentencePiece model. Set mode to "none" for pure SentencePiece tokenization.
+sp_model_path: ""
+
+# (optional) Joiner character to use for the tokenization to be reversible.
 joiner: ￭
+# (optional) Mark tokens with the joiner for reversible tokenization.
 joiner_annotate: false
+# (optional) Make the joiner character a new token (i.e. do not mark existing tokens).
 joiner_new: false
-case_feature: false
-no_substitution: false
+
+# (optional) Make tokenization reversible by marking spacer characters (alternative to joiner_annotate).
+spacer_annotate: false
+
+# (optional) Segment a word on casing changes (e.g. AbC -> Ab C).
 segment_case: false
+# (optional) Segment digits (e.g. 42 -> 4 2).
 segment_numbers: false
+# (optional) Segment on alphabet change.
 segment_alphabet_change: false
+# (optional) Segment all characters from these alphabets.
+# See the supported list here: https://github.com/OpenNMT/Tokenizer/blob/master/include/onmt/Alphabet.h
 segment_alphabet: []
+
+# (optional) The tokenization uses some special characters that if found in the
+# original text are replaced with alternatives. Set to true to disable.
+no_substitution: false
+
+# (unsupported) Casing features is currently unsupported.
+# Setting this option to true will only result in lowercasing each word.
+case_feature: false

--- a/docs/tokenization.md
+++ b/docs/tokenization.md
@@ -1,29 +1,27 @@
 # Tokenization
 
-OpenNMT-tf can use the OpenNMT [Tokenizer](https://github.com/OpenNMT/Tokenizer) as a plugin to provide advanced tokenization behaviors.
+OpenNMT-tf ships the OpenNMT [Tokenizer](https://github.com/OpenNMT/Tokenizer) as a dependency to provide advanced tokenization behaviors, either offline or online.
 
-## Installation
+*Note: the `pyonmttok` package is only supported on Linux as of now.*
 
-*Note: we plan to release a package on PyPi to facilitate the installation of this plugin.*
+## Configuration files
 
-1\. Follow the Tokenizer [installation instructions](https://github.com/OpenNMT/Tokenizer) with [Python bindings](https://github.com/OpenNMT/Tokenizer/tree/master/bindings/python).
+YAML files are used to set the tokenizer options to ensure consistency during data preparation and training. See the sample file `config/tokenization/sample.yml`.
 
-2\. Configure your environment for Python to find the newly generated package, e.g.:
+## Offline usage
 
-```bash
-export PYTHONPATH="$PYTHONPATH:$HOME/Tokenizer/build/bindings/python/"
-```
-
-3\. Test the plugin:
+You can invoke the `onmt-tokenize-text` script directly and select the `OpenNMTTokenizer` tokenizer:
 
 ```bash
 $ echo "Hello world!" | onmt-tokenize-text --tokenizer OpenNMTTokenizer
 Hello world !
+$ echo "Hello world!" | onmt-tokenize-text --tokenizer OpenNMTTokenizer --tokenizer_config config/tokenization/aggressive.yml
+Hello world ￭!
 ```
 
-## Usage
+## Online usage
 
-YAML files are used to set the tokenizer options to ensure consistency during data preparation and training. See the sample file `config/tokenization/sample.yml`.
+A key feature is the possibility to tokenize the data on-the-fly during the training. This avoids the need of storing tokenized files and also increases the consistency of your preprocessing pipeline.
 
 Here is an example workflow:
 

--- a/opennmt/tests/tokenizer_test.py
+++ b/opennmt/tests/tokenizer_test.py
@@ -2,7 +2,7 @@
 
 import tensorflow as tf
 
-from opennmt.tokenizers import SpaceTokenizer, CharacterTokenizer
+from opennmt.tokenizers import SpaceTokenizer, CharacterTokenizer, OpenNMTTokenizer
 
 
 class TokenizerTest(tf.test.TestCase):
@@ -67,6 +67,13 @@ class TokenizerTest(tf.test.TestCase):
     self._testTokenizer(CharacterTokenizer(), "a b", ["a", "▁", "b"])
     self._testDetokenizer(CharacterTokenizer(), [["a", "▁", "b"]], ["a b"])
     self._testTokenizer(CharacterTokenizer(), "你好，世界！", ["你", "好", "，", "世", "界", "！"])
+
+  def testOpenNMTTokenizer(self):
+    self._testTokenizer(OpenNMTTokenizer(), "Hello world!", ["Hello", "world", "!"])
+    self._testDetokenizer(
+        OpenNMTTokenizer(),
+        [["Hello", "world", "￭!"], ["Test"], ["My", "name"]],
+        ["Hello world!", "Test", "My name"])
 
 
 if __name__ == "__main__":

--- a/opennmt/tokenizers/opennmt_tokenizer.py
+++ b/opennmt/tokenizers/opennmt_tokenizer.py
@@ -27,9 +27,11 @@ def create_tokenizer(config):
 
   kwargs = {}
   _set(kwargs, "bpe_model_path")
+  _set(kwargs, "sp_model_path")
   _set(kwargs, "joiner")
   _set(kwargs, "joiner_annotate")
   _set(kwargs, "joiner_new")
+  _set(kwargs, "spacer_annotate")
   _set(kwargs, "case_feature")
   _set(kwargs, "no_substitution")
   _set(kwargs, "segment_case")

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     },
     keywords="tensorflow opennmt nmt neural machine translation",
     install_requires=[
+        "pyonmttok==1.*;platform_system=='Linux'",
         "pyyaml"
     ],
     extras_require={


### PR DESCRIPTION
This PR uses the recently released Python package of the OpenNMT Tokenizer to avoid a manual and cumbersome compilation. 