### PR TITLE
Return alignment history when decoding from an AttentionalRNNDecoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ OpenNMT-tf follows [semantic versioning 2.0.0](https://semver.org/). The API cov
 
 ### New features
 
+* Return alignment history when decoding from an `AttentionalRNNDecoder` (requires TensorFlow 1.8+ when decoding with beam search)
+
 ### Fixes and improvements
 
 ## [1.1.0](https://github.com/OpenNMT/OpenNMT-tf/releases/tag/v1.1.0) (2018-04-12)

--- a/opennmt/decoders/decoder.py
+++ b/opennmt/decoders/decoder.py
@@ -165,7 +165,8 @@ class Decoder(object):
                      mode=tf.estimator.ModeKeys.PREDICT,
                      memory=None,
                      memory_sequence_length=None,
-                     dtype=None):
+                     dtype=None,
+                     return_alignment_history=False):
     """Decodes dynamically from :obj:`start_tokens` with greedy search.
 
     Usually used for inference.
@@ -184,9 +185,14 @@ class Decoder(object):
       memory: (optional) Memory values to query.
       memory_sequence_length: (optional) Memory values length.
       dtype: The data type. Required if :obj:`memory` is ``None``.
+      return_alignment_history: If ``True``, also returns the alignment
+        history from the attention layer (``None`` will be returned if
+        unsupported by the decoder).
 
     Returns:
-      A tuple ``(predicted_ids, state, sequence_length, log_probs)``.
+      A tuple ``(predicted_ids, state, sequence_length, log_probs)`` or
+      ``(predicted_ids, state, sequence_length, log_probs, alignment_history)``
+      if :obj:`return_alignment_history` is ``True``.
     """
     raise NotImplementedError()
 
@@ -204,7 +210,8 @@ class Decoder(object):
                                 mode=tf.estimator.ModeKeys.PREDICT,
                                 memory=None,
                                 memory_sequence_length=None,
-                                dtype=None):
+                                dtype=None,
+                                return_alignment_history=False):
     """Decodes dynamically from :obj:`start_tokens` with beam search.
 
     Usually used for inference.
@@ -225,8 +232,13 @@ class Decoder(object):
       memory: (optional) Memory values to query.
       memory_sequence_length: (optional) Memory values length.
       dtype: The data type. Required if :obj:`memory` is ``None``.
+      return_alignment_history: If ``True``, also returns the alignment
+        history from the attention layer (``None`` will be returned if
+        unsupported by the decoder).
 
     Returns:
-      A tuple ``(predicted_ids, state, sequence_length, log_probs)``.
+      A tuple ``(predicted_ids, state, sequence_length, log_probs)`` or
+      ``(predicted_ids, state, sequence_length, log_probs, alignment_history)``
+      if :obj:`return_alignment_history` is ``True``.
     """
     raise NotImplementedError()

--- a/opennmt/decoders/rnn_decoder.py
+++ b/opennmt/decoders/rnn_decoder.py
@@ -54,8 +54,10 @@ class RNNDecoder(Decoder):
                   initial_state=None,
                   memory=None,
                   memory_sequence_length=None,
-                  dtype=None):
+                  dtype=None,
+                  alignment_history=False):
     _ = memory_sequence_length
+    _ = alignment_history
 
     if memory is None and dtype is None:
       raise ValueError("dtype argument is required when memory is not set")
@@ -144,7 +146,8 @@ class RNNDecoder(Decoder):
                      mode=tf.estimator.ModeKeys.PREDICT,
                      memory=None,
                      memory_sequence_length=None,
-                     dtype=None):
+                     dtype=None,
+                     return_alignment_history=False):
     batch_size = tf.shape(start_tokens)[0]
 
     helper = tf.contrib.seq2seq.GreedyEmbeddingHelper(
@@ -158,7 +161,8 @@ class RNNDecoder(Decoder):
         initial_state=initial_state,
         memory=memory,
         memory_sequence_length=memory_sequence_length,
-        dtype=dtype)
+        dtype=dtype,
+        alignment_history=return_alignment_history)
 
     if output_layer is None:
       output_layer = build_output_layer(self.num_units, vocab_size, dtype=dtype or memory.dtype)
@@ -180,6 +184,11 @@ class RNNDecoder(Decoder):
     length = tf.expand_dims(length, 1)
     log_probs = tf.expand_dims(log_probs, 1)
 
+    if return_alignment_history:
+      alignment_history = _get_alignment_history(state)
+      if alignment_history is not None:
+        alignment_history = tf.expand_dims(alignment_history, 2)
+      return (predicted_ids, state, length, log_probs, alignment_history)
     return (predicted_ids, state, length, log_probs)
 
   def dynamic_decode_and_search(self,
@@ -195,7 +204,17 @@ class RNNDecoder(Decoder):
                                 mode=tf.estimator.ModeKeys.PREDICT,
                                 memory=None,
                                 memory_sequence_length=None,
-                                dtype=None):
+                                dtype=None,
+                                return_alignment_history=False):
+    if (return_alignment_history and
+        "reorder_tensor_arrays" not in fn_args(tf.contrib.seq2seq.BeamSearchDecoder.__init__)):
+      tf.logging.warn("The current version of tf.contrib.seq2seq.BeamSearchDecoder "
+                      "does not support returning the alignment history. None will "
+                      "be returned instead. Consider upgrading TensorFlow.")
+      alignment_history = False
+    else:
+      alignment_history = return_alignment_history
+
     batch_size = tf.shape(start_tokens)[0]
 
     # Replicate batch `beam_width` times.
@@ -215,7 +234,8 @@ class RNNDecoder(Decoder):
         initial_state=initial_state,
         memory=memory,
         memory_sequence_length=memory_sequence_length,
-        dtype=dtype)
+        dtype=dtype,
+        alignment_history=alignment_history)
 
     if output_layer is None:
       output_layer = build_output_layer(self.num_units, vocab_size, dtype=dtype or memory.dtype)
@@ -237,8 +257,23 @@ class RNNDecoder(Decoder):
     log_probs = beam_state.log_probs
     state = beam_state.cell_state
 
+    if return_alignment_history:
+      alignment_history = _get_alignment_history(state)
+      if alignment_history is not None:
+        alignment_history = tf.reshape(
+            alignment_history, [-1, batch_size, beam_width, tf.shape(memory)[1]])
+      return (predicted_ids, state, length, log_probs, alignment_history)
     return (predicted_ids, state, length, log_probs)
 
+
+def _get_alignment_history(cell_state):
+  """Returns the alignment history from the cell state."""
+  if not hasattr(cell_state, "alignment_history") or cell_state.alignment_history == ():
+    return None
+  alignment_history = cell_state.alignment_history
+  if isinstance(alignment_history, tf.TensorArray):
+    alignment_history = alignment_history.stack()
+  return alignment_history
 
 def _build_attention_mechanism(attention_mechanism,
                                num_units,
@@ -310,7 +345,8 @@ class AttentionalRNNDecoder(RNNDecoder):
                   initial_state=None,
                   memory=None,
                   memory_sequence_length=None,
-                  dtype=None):
+                  dtype=None,
+                  alignment_history=False):
     attention_mechanism = _build_attention_mechanism(
         self.attention_mechanism_class,
         self.num_units,
@@ -328,6 +364,7 @@ class AttentionalRNNDecoder(RNNDecoder):
         cell,
         attention_mechanism,
         attention_layer_size=self.num_units,
+        alignment_history=alignment_history,
         output_attention=self.output_is_attention,
         initial_cell_state=initial_cell_state)
 
@@ -398,7 +435,8 @@ class MultiAttentionalRNNDecoder(RNNDecoder):
                   initial_state=None,
                   memory=None,
                   memory_sequence_length=None,
-                  dtype=None):
+                  dtype=None,
+                  alignment_history=False):
     attention_mechanisms = [
         _build_attention_mechanism(
             attention_mechanism,

--- a/opennmt/decoders/self_attention_decoder.py
+++ b/opennmt/decoders/self_attention_decoder.py
@@ -221,7 +221,8 @@ class SelfAttentionDecoder(Decoder):
                      mode=tf.estimator.ModeKeys.PREDICT,
                      memory=None,
                      memory_sequence_length=None,
-                     dtype=None):
+                     dtype=None,
+                     return_alignment_history=False):
     batch_size = tf.shape(start_tokens)[0]
     finished = tf.tile([False], [batch_size])
     step = tf.constant(0)
@@ -282,6 +283,8 @@ class SelfAttentionDecoder(Decoder):
     lengths = tf.expand_dims(lengths, 1)
     log_probs = tf.expand_dims(log_probs, 1)
 
+    if return_alignment_history:
+      return (outputs, None, lengths, log_probs, None)
     return (outputs, None, lengths, log_probs)
 
 
@@ -298,7 +301,8 @@ class SelfAttentionDecoder(Decoder):
                                 mode=tf.estimator.ModeKeys.PREDICT,
                                 memory=None,
                                 memory_sequence_length=None,
-                                dtype=None):
+                                dtype=None,
+                                return_alignment_history=False):
     cache = self._init_cache(memory, memory_sequence_length=memory_sequence_length)
     symbols_to_logits_fn = self._symbols_to_logits_fn(
         embedding, vocab_size, mode, output_layer=output_layer, dtype=dtype or memory.dtype)
@@ -318,4 +322,6 @@ class SelfAttentionDecoder(Decoder):
     lengths = tf.cast(lengths, tf.int32)
     lengths = tf.reduce_sum(lengths, axis=-1)
 
+    if return_alignment_history:
+      return (outputs, None, lengths, log_probs, None)
     return (outputs, None, lengths, log_probs)


### PR DESCRIPTION
Starting from TensorFlow 1.8, alignment history can be returned when using a standard `AttentionalRNNDecoder` in both greedy and beam search.

Closes #2.