### PR TITLE
Fix a typo in scripts/wmt/README.md

### DIFF
--- a/scripts/wmt/README.md
+++ b/scripts/wmt/README.md
@@ -58,6 +58,6 @@ This model achieved the following scores:
 | Test set | NIST BLEU |
 | --- | --- |
 | newstest2014 | 26.9 |
-| neswtest2017 | 28.0 |
+| newstest2017 | 28.0 |
 
 (*) *The model was exported with TensorFlow 1.7.0 and OpenNMT-tf 1.1.0.*


### PR DESCRIPTION
I noticed a typo and thought that fixing it would be a good practical intro (after reading CONTRIBUTING.md) to OpenNMT-tf, a project that looks very promising to me.

Test plan:
Given that this commit deals with documentation, I have conducted visual testing.