### PR TITLE
Fix synchronous multi GPU seq2seq training

### DIFF
--- a/opennmt/decoders/rnn_decoder.py
+++ b/opennmt/decoders/rnn_decoder.py
@@ -8,6 +8,7 @@ from tensorflow.python.estimator.util import fn_args
 
 from opennmt.decoders.decoder import Decoder, logits_to_cum_log_probs, build_output_layer
 from opennmt.utils.cell import build_cell
+from opennmt.layers.reducer import align_in_time
 
 
 class RNNDecoder(Decoder):
@@ -132,6 +133,9 @@ class RNNDecoder(Decoder):
       logits = output_layer(outputs.rnn_output)
     else:
       logits = outputs.rnn_output
+    # Make sure outputs have the same time_dim as inputs
+    inputs_len = tf.shape(inputs)[1]
+    logits = align_in_time(logits, inputs_len)
 
     return (logits, state, length)
 


### PR DESCRIPTION
Fix issue #137 .
RNNDecoder.decode() output time dimension may be smaller than inputs' if max(sequence_length) < input size time dim, which happens in synchronous multi GPU training. This PR makes sure that they are the same, which is necessary for correct loss computation.

With this patch multi GPU training works, but I haven't done any speed benchmarks.