### PR TITLE
Fix encoding issue with sample

### DIFF
--- a/examples/serving/nmt_client.py
+++ b/examples/serving/nmt_client.py
@@ -80,7 +80,8 @@ def main():
 
   for tokens, future in zip(batch_tokens, futures):
     result = parse_translation_result(future.result())
-    print("{} ||| {}".format(" ".join(tokens), " ".join(result)))
+    print("{} ||| {}".format(" ".join(tokens), " ".
+          join(token.decode("utf-8") for token in result)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When executing the sample nmt_client.py in Python3 under Ubuntu I get this error:

Traceback (most recent call last):
File "nmt_client.py", line 87, in 
main()
File "nmt_client.py", line 83, in main
print("{} ||| {}".format(" ".join(tokens), " ".join(result)))

In order to execute the sample I needed to make the change in this pull request. Sent it to you in case it's useful (works with Python 2 and Python 3)