### PR TITLE
Revert usage of embedding_lookup wrapper

### DIFF
--- a/opennmt/decoders/decoder.py
+++ b/opennmt/decoders/decoder.py
@@ -5,7 +5,6 @@ import six
 
 import tensorflow as tf
 
-from opennmt.layers.common import embedding_lookup
 from opennmt.utils.beam_search import get_state_shape_invariants
 
 
@@ -42,7 +41,7 @@ def get_embedding_fn(embedding):
   if callable(embedding):
     return embedding
   else:
-    return lambda ids: embedding_lookup(embedding, ids)
+    return lambda ids: tf.nn.embedding_lookup(embedding, ids)
 
 def build_output_layer(num_units, vocab_size, dtype=None):
   """Builds the output projection layer.

--- a/opennmt/inputters/text_inputter.py
+++ b/opennmt/inputters/text_inputter.py
@@ -17,7 +17,6 @@ from opennmt.inputters.inputter import Inputter
 from opennmt.utils.cell import build_cell, last_encoding_from_state
 from opennmt.utils.misc import count_lines
 from opennmt.constants import PADDING_TOKEN
-from opennmt.layers.common import embedding_lookup
 
 
 def visualize_embeddings(log_dir, embedding_var, vocabulary_file, num_oov_buckets=1):
@@ -389,7 +388,7 @@ class WordEmbedder(TextInputter):
           initializer=initializer,
           trainable=self.trainable)
 
-    outputs = embedding_lookup(embeddings, inputs)
+    outputs = tf.nn.embedding_lookup(embeddings, inputs)
 
     outputs = tf.layers.dropout(
         outputs,
@@ -478,7 +477,7 @@ class CharEmbedder(TextInputter):
     embeddings = tf.get_variable(
         "w_char_embs", shape=[self.vocabulary_size, self.embedding_size], dtype=self.dtype)
 
-    outputs = embedding_lookup(embeddings, inputs)
+    outputs = tf.nn.embedding_lookup(embeddings, inputs)
     outputs = tf.layers.dropout(
         outputs,
         rate=self.dropout,

--- a/opennmt/layers/position.py
+++ b/opennmt/layers/position.py
@@ -7,7 +7,6 @@ import six
 import tensorflow as tf
 
 from opennmt.layers.reducer import SumReducer
-from opennmt.layers.common import embedding_lookup
 
 
 def make_positions(sequence_length, maximum_length=None):
@@ -158,7 +157,7 @@ class PositionEmbedder(PositionEncoder):
     positions = tf.minimum(positions, self.maximum_position)
     embeddings = tf.get_variable(
         "w_embs", shape=[self.maximum_position + 1, depth], dtype=dtype)
-    return embedding_lookup(embeddings, positions)
+    return tf.nn.embedding_lookup(embeddings, positions)
 
 
 class SinusoidalPositionEncoder(PositionEncoder):


### PR DESCRIPTION
This change introduced in e3e006c6 was required when Adafactor crashed
on sparse updates. The fallback to dense gradients is now implemented
in the optimizer itself.