### PR TITLE
Manually check tensor depth in states compatibility assert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ OpenNMT-tf follows [semantic versioning 2.0.0](https://semver.org/). The API cov
 ### Fixes and improvements
 
 * Fix possible error when loading checkpoints without `--model_type` or `--model` after updating to a newer OpenNMT-tf version. The saved model description is now more future-proof regarding model class updates.
+* Improve encoder/decoder states compatibility check
 
 ## [1.10.0](https://github.com/OpenNMT/OpenNMT-tf/releases/tag/v1.10.0) (2018-10-11)
 

--- a/opennmt/layers/bridge.py
+++ b/opennmt/layers/bridge.py
@@ -25,7 +25,11 @@ def assert_state_is_compatible(expected_state, state):
 
   for x, y in zip(expected_state_flat, state_flat):
     if tf.contrib.framework.is_tensor(x):
-      tf.contrib.framework.with_same_shape(x, y)
+      expected_depth = x.get_shape().as_list()[-1]
+      depth = y.get_shape().as_list()[-1]
+      if depth != expected_depth:
+        raise ValueError("Tensor %s in state has shape %s which is incompatible "
+                         "with the target shape %s" % (y.name, y.shape, x.shape))
 
 
 @six.add_metaclass(abc.ABCMeta)


### PR DESCRIPTION
The previously used function `tf.contrib.framework.with_same_shape` did not throw but attached an assert op dependency to the input tensor.