### PR TITLE
Name projector metadata file with the embedding variable name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ OpenNMT-tf follows [semantic versioning 2.0.0](https://semver.org/). The API cov
 ### Fixes and improvements
 
 * Fix possible error when loading checkpoints without `--model_type` or `--model` after updating to a newer OpenNMT-tf version. The saved model description is now more future-proof regarding model class updates.
+* Fix embedding visualization when the vocabulary file is stored in the model directory or when a joint vocabulary is used
 * Improve encoder/decoder states compatibility check
 
 ## [1.10.0](https://github.com/OpenNMT/OpenNMT-tf/releases/tag/v1.10.0) (2018-10-11)

--- a/opennmt/inputters/text_inputter.py
+++ b/opennmt/inputters/text_inputter.py
@@ -33,18 +33,17 @@ def visualize_embeddings(log_dir, embedding_var, vocabulary_file, num_oov_bucket
     num_oov_buckets: The number of additional unknown tokens.
   """
   # Copy vocabulary file to log_dir.
-  basename = os.path.basename(vocabulary_file)
+  basename = "%s.txt" % embedding_var.op.name.replace("/", "_")
   destination = os.path.join(log_dir, basename)
-  if vocabulary_file != destination:
-    tf.gfile.Copy(vocabulary_file, destination, overwrite=True)
+  tf.gfile.Copy(vocabulary_file, destination, overwrite=True)
 
-    # Append <unk> tokens.
-    with tf.gfile.Open(destination, mode="ab") as vocab:
-      if num_oov_buckets == 1:
-        vocab.write(b"<unk>\n")
-      else:
-        for i in range(num_oov_buckets):
-          vocab.write(tf.compat.as_bytes("<unk%d>\n" % i))
+  # Append <unk> tokens.
+  with tf.gfile.Open(destination, mode="ab") as vocab:
+    if num_oov_buckets == 1:
+      vocab.write(b"<unk>\n")
+    else:
+      for i in range(num_oov_buckets):
+        vocab.write(tf.compat.as_bytes("<unk%d>\n" % i))
 
   config = projector.ProjectorConfig()
 


### PR DESCRIPTION
This fixes issues when the vocabulary is stored in the model directory or when the model uses a joint vocabulary.