### PR TITLE
Workaround model export error on SequenceRecordInputter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ OpenNMT-tf follows [semantic versioning 2.0.0](https://semver.org/). The API cov
 
 ### Fixes and improvements
 
+* Fix error when exporting models containing a `SequenceRecordInputter`
+
 ## [1.15.0](https://github.com/OpenNMT/OpenNMT-tf/releases/tag/v1.15.0) (2018-11-30)
 
 ### New features

--- a/opennmt/models/model.py
+++ b/opennmt/models/model.py
@@ -494,6 +494,11 @@ class Model(object):
   def _serving_input_fn_impl(self, metadata):
     """See ``serving_input_fn``."""
     self._initialize(metadata)
+    # This is a hack for SequenceRecordInputter that currently infers the input
+    # depth from the data files.
+    # TODO: This method should not require the training data.
+    if self.features_inputter is not None and "train_features_file" in metadata:
+      _ = self.features_inputter.make_dataset(metadata["train_features_file"])
     return self._get_serving_input_receiver()
 
   def serving_input_fn(self, metadata):


### PR DESCRIPTION
This class currently infers the input depth from the training data. However, this code was not invoked when exporting the inputs for serving.

As a workaround, if the training data is found in the configuration at export time, the depth detection code is called.

Fixes #289.