### PR TITLE
Fix offset in alignment vectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ OpenNMT-tf follows [semantic versioning 2.0.0](https://semver.org/). The API cov
 
 ### Fixes and improvements
 
+* Fix offset in alignment vectors introduced by the `<s>` special token
+
 ## [1.17.0](https://github.com/OpenNMT/OpenNMT-tf/releases/tag/v1.17.0) (2019-01-10)
 
 ### New features

--- a/opennmt/decoders/decoder.py
+++ b/opennmt/decoders/decoder.py
@@ -400,6 +400,8 @@ class Decoder(object):
       log_probs = tf.expand_dims(log_probs, 1)
       if attention is not None:
         attention = tf.expand_dims(attention, 1)
+    if attention is not None:
+      attention = attention[:, :, 1:]  # Ignore attention for <s>.
 
     if return_alignment_history:
       return (outputs, state["decoder"], lengths, log_probs, attention)

--- a/opennmt/tests/decoder_test.py
+++ b/opennmt/tests/decoder_test.py
@@ -180,7 +180,7 @@ class DecoderTest(tf.test.TestCase):
           alignment_history, decode_time, memory_time = sess.run(
               [alignment_history, tf.shape(ids)[-1], tf.shape(memory)[1]])
           self.assertAllEqual(
-              [batch_size, num_hyps, decode_time, memory_time], alignment_history.shape)
+              [batch_size, num_hyps, decode_time - 1, memory_time], alignment_history.shape)
         else:
           self.assertIsNone(alignment_history)
 

--- a/opennmt/tests/sequence_to_sequence_test.py
+++ b/opennmt/tests/sequence_to_sequence_test.py
@@ -70,6 +70,7 @@ class SequenceToSequenceTest(tf.test.TestCase):
       self.assertListEqual(expected_matrix, sess.run(matrix).tolist())
 
   def testPharaohAlignments(self):
+    self._testPharaohAlignments("", [0, 0], [])
     self._testPharaohAlignments("0-0", [1, 1], [[1]])
     self._testPharaohAlignments(
         "0-0 1-1 2-2 3-3", [4, 4], [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]])


### PR DESCRIPTION
* During guided alignment, we should constrain the alignments of  "a b c" and not "\<s> a b c".
* During decoding, we should return the alignments of "a b c" and not  "\<s> a b".