### PR TITLE
Simplify configuration of on-the-fly tokenization

### DIFF
--- a/docs/configuration_reference.md
+++ b/docs/configuration_reference.md
@@ -20,6 +20,14 @@ data:
   source_words_vocabulary: data/toy-ende/src-vocab.txt
   target_words_vocabulary: data/toy-ende/tgt-vocab.txt
 
+  # (optional) OpenNMT tokenization configuration (or path to a configuration file).
+  # See also: https://github.com/OpenNMT/Tokenizer/blob/master/docs/options.md
+  source_tokenization:
+    mode: aggressive
+    joiner_annotate: true
+    segment_numbers: true
+    segment_alphabet_change: true
+  target_tokenization: config/tokenization/aggressive.yml
 
 # Model and optimization parameters.
 params:

--- a/docs/tokenization.md
+++ b/docs/tokenization.md
@@ -1,6 +1,8 @@
 # Tokenization
 
-By default, OpenNMT-tf **expects and generates tokenized text**. The user is thus responsible to tokenize the input and detokenize the output. However, OpenNMT-tf provides tokenization tools based on the C++ OpenNMT [Tokenizer](https://github.com/OpenNMT/Tokenizer) that can be used in 2 ways:
+By default, OpenNMT-tf **expects and generates tokenized text**. The users are thus responsible to tokenize the input and detokenize the output with the tool of their choice.
+
+However, OpenNMT-tf provides tokenization tools based on the C++ OpenNMT [Tokenizer](https://github.com/OpenNMT/Tokenizer) that can be used in 2 ways:
 
 * *offline*: use the provided scripts to manually tokenize the text files before the execution and detokenize the output for evaluation
 * *online*: configure the execution to apply tokenization and detokenization on-the-fly
@@ -9,7 +11,7 @@ By default, OpenNMT-tf **expects and generates tokenized text**. The user is thu
 
 ## Configuration files
 
-YAML files are used to set the tokenizer options to ensure consistency during data preparation and training. For example:
+YAML files are used to set the tokenizer options to ensure consistency during data preparation and training. For example, this configuration defines in simple word-based tokenization using the OpenNMT tokenizer:
 
 ```yaml
 mode: aggressive
@@ -22,12 +24,10 @@ segment_alphabet_change: true
 
 ## Offline usage
 
-You can invoke the `onmt-tokenize-text` script directly and select the `OpenNMTTokenizer` tokenizer:
+You can invoke the `onmt-tokenize-text` script directly and pass the tokenizer configuration:
 
 ```bash
-$ echo "Hello world!" | onmt-tokenize-text --tokenizer OpenNMTTokenizer
-Hello world !
-$ echo "Hello world!" | onmt-tokenize-text --tokenizer OpenNMTTokenizer --tokenizer_config config/tokenization/aggressive.yml
+$ echo "Hello world!" | onmt-tokenize-text --tokenizer_config config/tokenization/aggressive.yml
 Hello world ￭!
 ```
 
@@ -40,35 +40,18 @@ Here is an example workflow:
 1\. Build the vocabularies with the custom tokenizer, e.g.:
 
 ```bash
-onmt-build-vocab --tokenizer OpenNMTTokenizer --tokenizer_config config/tokenization/aggressive.yml --size 50000 --save_vocab data/enfr/en-vocab.txt data/enfr/en-train.txt
-onmt-build-vocab --tokenizer OpenNMTTokenizer --tokenizer_config config/tokenization/aggressive.yml --size 50000 --save_vocab data/enfr/fr-vocab.txt data/enfr/fr-train.txt
+onmt-build-vocab --tokenizer_config config/tokenization/aggressive.yml --size 50000 --save_vocab data/enfr/en-vocab.txt data/enfr/en-train.txt
+onmt-build-vocab --tokenizer_config config/tokenization/aggressive.yml --size 50000 --save_vocab data/enfr/fr-vocab.txt data/enfr/fr-train.txt
 ```
 
 *The text files are only given as examples and are not part of the repository.*
 
-2\. Update your model's `TextInputter`s to use the custom tokenizer, e.g.:
-
-```python
-return onmt.models.SequenceToSequence(
-    source_inputter=onmt.inputters.WordEmbedder(
-        vocabulary_file_key="source_words_vocabulary",
-        embedding_size=512,
-        tokenizer=onmt.tokenizers.OpenNMTTokenizer(
-            configuration_file_or_key="source_tokenizer_config")),
-    target_inputter=onmt.inputters.WordEmbedder(
-        vocabulary_file_key="target_words_vocabulary",
-        embedding_size=512,
-        tokenizer=onmt.tokenizers.OpenNMTTokenizer(
-            configuration_file_or_key="target_tokenizer_config")),
-    ...)
-```
-
-3\. Reference the tokenizer configurations in the data configuration, e.g.:
+2\. Reference the tokenizer configurations in the data configuration, e.g.:
 
 ```yaml
 data:
-  source_tokenizer_config: config/tokenization/aggressive.yml
-  target_tokenizer_config: config/tokenization/aggressive.yml
+  source_tokenization: config/tokenization/aggressive.yml
+  target_tokenization: config/tokenization/aggressive.yml
 ```
 
 ## Notes

--- a/opennmt/inputters/inputter.py
+++ b/opennmt/inputters/inputter.py
@@ -263,7 +263,7 @@ class MultiInputter(Inputter):
     assets = {}
     for i, inputter in enumerate(self.inputters):
       assets.update(inputter.initialize(
-          metadata, asset_dir=asset_dir, asset_prefix="%s%d_" % (asset_prefix, i)))
+          metadata, asset_dir=asset_dir, asset_prefix="%s%d_" % (asset_prefix, i + 1)))
     return assets
 
   def visualize(self, log_dir):

--- a/opennmt/tests/inputter_test.py
+++ b/opennmt/tests/inputter_test.py
@@ -188,6 +188,32 @@ class InputterTest(tf.test.TestCase):
       self.assertAllEqual([[2, 1, 4]], features["ids"])
       self.assertAllEqual([1, 3, 10], transformed.shape)
 
+  def testWordEmbedderWithTokenizer(self):
+    vocab_file = self._makeTextFile("vocab.txt", ["the", "world", "hello", "￭"])
+    data_file = self._makeTextFile("data.txt", ["hello world!"])
+
+    embedder = text_inputter.WordEmbedder("vocabulary_file", embedding_size=10)
+    metadata = {
+        "vocabulary_file": vocab_file,
+        "tokenization": {
+            "mode": "aggressive",
+            "joiner_annotate": True,
+            "joiner_new": True
+        }
+    }
+    features, transformed = self._makeDataset(
+        embedder,
+        data_file,
+        metadata=metadata,
+        shapes={"tokens": [None, None], "ids": [None, None], "length": [None]})
+
+    with self.test_session() as sess:
+      sess.run(tf.tables_initializer())
+      sess.run(tf.global_variables_initializer())
+      features, transformed = sess.run([features, transformed])
+      self.assertAllEqual([4], features["length"])
+      self.assertAllEqual([[2, 1, 3, 4]], features["ids"])
+
   def testWordEmbedderWithPretrainedEmbeddings(self):
     data_file = self._makeTextFile("data.txt", ["hello world !"])
     vocab_file = self._makeTextFile("vocab.txt", ["the", "world", "hello", "toto"])

--- a/opennmt/tokenizers/__init__.py
+++ b/opennmt/tokenizers/__init__.py
@@ -19,7 +19,7 @@ def add_command_line_arguments(parser):
   choices = list(classes_in_module(sys.modules[__name__]))
 
   parser.add_argument(
-      "--tokenizer", default="SpaceTokenizer", choices=choices,
+      "--tokenizer", default=None, choices=choices,
       help="Tokenizer class name.")
   parser.add_argument(
       "--tokenizer_config", default=None,
@@ -28,4 +28,11 @@ def add_command_line_arguments(parser):
 def build_tokenizer(args):
   """Returns a new tokenizer based on command line arguments."""
   module = sys.modules[__name__]
-  return getattr(module, args.tokenizer)(configuration_file_or_key=args.tokenizer_config)
+  if args.tokenizer is None:
+    if args.tokenizer_config:
+      tokenizer_class = OpenNMTTokenizer
+    else:
+      tokenizer_class = SpaceTokenizer
+  else:
+    tokenizer_class = getattr(module, args.tokenizer)
+  return tokenizer_class(configuration_file_or_key=args.tokenizer_config)


### PR DESCRIPTION
In particular, do not require to change the model definition to configure the tokenization.