### PR TITLE
fix score function bug

### DIFF
--- a/opennmt/runner.py
+++ b/opennmt/runner.py
@@ -448,7 +448,7 @@ class Runner(object):
       ValueError: if no checkpoint are found or if the model is not a sequence to
         sequence model.
     """
-    if not hasattr(self._model, "target_inputter"):
+    if not hasattr(self._model, "examples_inputter"):
       raise ValueError("scoring only works for sequence to sequence models")
 
     if checkpoint_path is None:


### PR DESCRIPTION
'onmt-main score' can't work.It check whether the model has attribute 'target_inputter',but this attribute had been changed to 'examples_inputter'.