### PR TITLE
Do not rebuild input and output layers under reused scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ OpenNMT-tf follows [semantic versioning 2.0.0](https://semver.org/). The API cov
 
 ### Fixes and improvements
 
+* Fix multi GPU training: some variables were not correctly reused when building the graph for other devices 
+
 ## [1.21.2](https://github.com/OpenNMT/OpenNMT-tf/releases/tag/v1.21.2) (2019-03-05)
 
 ### Fixes and improvements

--- a/opennmt/models/language_model.py
+++ b/opennmt/models/language_model.py
@@ -48,11 +48,7 @@ class LanguageModel(Model):
         }
     })
 
-  def _call(self, features, labels, params, mode):
-    training = mode == tf.estimator.ModeKeys.TRAIN
-    outputs, predictions = None, None
-
-    # Initialize input and output layers.
+  def _build(self):
     self.examples_inputter.build()
     vocab_size = self.examples_inputter.vocabulary_size
     output_layer = None
@@ -63,6 +59,10 @@ class LanguageModel(Model):
           transpose=True,
           dtype=self.examples_inputter.dtype)
     self.decoder.initialize(vocab_size=vocab_size, output_layer=output_layer)
+
+  def _call(self, features, labels, params, mode):
+    training = mode == tf.estimator.ModeKeys.TRAIN
+    outputs, predictions = None, None
 
     ids, length = features["ids"], features["length"]
     if mode != tf.estimator.ModeKeys.PREDICT:

--- a/opennmt/models/model.py
+++ b/opennmt/models/model.py
@@ -9,6 +9,7 @@ import tensorflow as tf
 
 from opennmt import estimator
 from opennmt import inputters
+from opennmt.utils import compat
 from opennmt.utils.optim import optimize_loss
 
 
@@ -82,6 +83,8 @@ class Model(tf.keras.layers.Layer):
       the arguments of this function.
     """
     with tf.variable_scope(self.name, initializer=self._initializer(params)):
+      if not compat.reuse():
+        self._build()  # Always rebuild unless the scope is marked for reuse.
       return self._call(features, labels, params, mode)
 
   def _initializer(self, params):
@@ -98,6 +101,10 @@ class Model(tf.keras.layers.Layer):
       return tf.random_uniform_initializer(
           minval=-param_init, maxval=param_init, dtype=self.dtype)
     return None
+
+  def _build(self):
+    """Builds stateful layers."""
+    return
 
   @abc.abstractmethod
   def _call(self, features, labels, params, mode):


### PR DESCRIPTION
This iterates on ea72cb3 to correctly better handle stateful layers.

Fixes #371.