### PR TITLE
Mark variable scope for reuse in LM inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ OpenNMT-tf follows [semantic versioning 2.0.0](https://semver.org/). The API cov
 ### Fixes and improvements
 
 * Fix compatibility issue with legacy TensorFlow 1.4
+* Fix inference of language models
 
 ## [1.21.4](https://github.com/OpenNMT/OpenNMT-tf/releases/tag/v1.21.4) (2019-03-07)
 

--- a/opennmt/models/language_model.py
+++ b/opennmt/models/language_model.py
@@ -87,16 +87,17 @@ class LanguageModel(Model):
             name=self.name + "/")  # Force the name scope.
 
       # Iteratively decode from the last decoder state.
-      sampled_ids, sampled_length, _ = decoder_util.greedy_decode(
-          self._decode,
-          tf.squeeze(start_ids, 1),
-          constants.END_OF_SENTENCE_ID,
-          decode_length=params.get("maximum_iterations", 250),
-          state=state,
-          min_decode_length=params.get("minimum_decoding_length", 0),
-          last_step_as_input=True,
-          sample_from=params.get("sampling_topk", 1),
-          sample_temperature=params.get("sampling_temperature", 1))
+      with tf.variable_scope(tf.get_variable_scope(), reuse=True):
+        sampled_ids, sampled_length, _ = decoder_util.greedy_decode(
+            self._decode,
+            tf.squeeze(start_ids, 1),
+            constants.END_OF_SENTENCE_ID,
+            decode_length=params.get("maximum_iterations", 250),
+            state=state,
+            min_decode_length=params.get("minimum_decoding_length", 0),
+            last_step_as_input=True,
+            sample_from=params.get("sampling_topk", 1),
+            sample_temperature=params.get("sampling_temperature", 1))
 
       # Build the full prediction.
       full_ids = tf.concat([ids, sampled_ids], 1)


### PR DESCRIPTION
Some stateful layers like PositionEmbedder recreates their variables unless the scope is marked for reuse.

Fixes #377.