### PR TITLE
Fix unexpected number of hypotheses returned by exported models

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -144,6 +144,9 @@ params:
 
   # (optional) Width of the beam search (default: 1).
   beam_width: 5
+  # (optional) Number of hypotheses to return (default: 1). Set 0 to return all
+  # available hypotheses. This value is also set by infer/n_best.
+  num_hypotheses: 1
   # (optional) Length penaly weight to apply on hypotheses (default: 0).
   length_penalty: 0.2
   # (optional) Sample predictions from the top K most likely tokens (requires
@@ -270,6 +273,7 @@ infer:
   prefetch_buffer_size: 1
 
   # (optional) For compatible models, the number of hypotheses to output (default: 1).
+  # This sets the parameter params/num_hypotheses.
   n_best: 1
   # (optional) For compatible models, also output the score (default: false).
   with_scores: false

--- a/opennmt/runner.py
+++ b/opennmt/runner.py
@@ -151,6 +151,8 @@ class Runner(object):
       run_config = run_config.replace(
           keep_checkpoint_max=train_config["keep_checkpoint_max"])
 
+    params.setdefault("num_hypotheses", self._config["infer"].get("n_best", 1))
+
     devices = get_devices(num_devices=self._num_devices, session_config=self._session_config)
     return tf.estimator.Estimator(
         estimator_util.make_model_fn(

--- a/opennmt/tests/model_test.py
+++ b/opennmt/tests/model_test.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import os
+import six
 
 from parameterized import parameterized
 from numbers import Number
@@ -182,6 +183,7 @@ class ModelTest(tf.test.TestCase):
       _, predictions = model(
           features, None, model.auto_config()["params"], tf.estimator.ModeKeys.PREDICT)
       self.assertIsInstance(predictions, dict)
+      self.assertEqual(six.next(six.itervalues(predictions)).shape[1], 1)
 
   @parameterized.expand([
       [tf.estimator.ModeKeys.TRAIN],


### PR DESCRIPTION
Default to returning the best hypothesis only (like command line inference does) and read params/num_hypotheses and infer/n_best to set the number of returned hypotheses.