### PR TITLE
Dont dropout if only 1 word

### DIFF
--- a/opennmt/layers/noise.py
+++ b/opennmt/layers/noise.py
@@ -146,15 +146,12 @@ class WordDropout(Noise):
     if self.dropout == 0:
       return tf.identity(words)
     num_words = tf.shape(words, out_type=tf.int64)[0]
-    # Keep at least 1 word.
-    if tf.equal(num_words, 1):
-      return tf.identity(words)
     keep_mask = random_mask([num_words], 1 - self.dropout)
     keep_ind = tf.where(keep_mask)
     # Keep at least one word.
     keep_ind = tf.cond(
         tf.equal(tf.shape(keep_ind)[0], 0),
-        true_fn=lambda: tf.random.uniform([1], maxval=num_words - 1, dtype=tf.int64),
+        true_fn=lambda: tf.random.uniform([1], maxval=num_words, dtype=tf.int64),
         false_fn=lambda: tf.squeeze(keep_ind, -1))
     return tf.gather(words, keep_ind)
 

--- a/opennmt/layers/noise.py
+++ b/opennmt/layers/noise.py
@@ -146,6 +146,9 @@ class WordDropout(Noise):
     if self.dropout == 0:
       return tf.identity(words)
     num_words = tf.shape(words, out_type=tf.int64)[0]
+    # Keep at least 1 word.
+    if tf.equal(num_words, 1):
+      return tf.identity(words)
     keep_mask = random_mask([num_words], 1 - self.dropout)
     keep_ind = tf.where(keep_mask)
     # Keep at least one word.

--- a/opennmt/tests/noise_test.py
+++ b/opennmt/tests/noise_test.py
@@ -53,6 +53,16 @@ class NoiseTest(tf.test.TestCase):
     y = self.evaluate(y)
     self.assertEqual(y.shape[0], 1)  # At least one is not dropped.
 
+  @parameterized.expand([
+    [["a"]],
+    [[""], ["c"]]],
+  ])
+  def testSingleWordDropoutAll(self, words):
+    x = tf.constant(words)
+    y = noise.WordDropout(1)(x)
+    y = self.evaluate(y)
+    self.assertEqual(y.shape[0], 1)  # One word is outputted.
+
   @parameterized.expand([[1], [2], [4], [5]])
   def testWordOmission(self, count):
     words = [["a", "b", ""], ["c", "", ""], ["d", "e", "f"], ["g", "", ""]]

--- a/opennmt/tests/noise_test.py
+++ b/opennmt/tests/noise_test.py
@@ -53,16 +53,6 @@ class NoiseTest(tf.test.TestCase):
     y = self.evaluate(y)
     self.assertEqual(y.shape[0], 1)  # At least one is not dropped.
 
-  @parameterized.expand([
-    [["a"]],
-    [[""], ["c"]]],
-  ])
-  def testSingleWordDropoutAll(self, words):
-    x = tf.constant(words)
-    y = noise.WordDropout(1)(x)
-    y = self.evaluate(y)
-    self.assertEqual(y.shape[0], 1)  # One word is outputted.
-
   @parameterized.expand([[1], [2], [4], [5]])
   def testWordOmission(self, count):
     words = [["a", "b", ""], ["c", "", ""], ["d", "e", "f"], ["g", "", ""]]


### PR DESCRIPTION
Returns `tf.identity(words)` if there is only one word.

Currently in master, if `num_words` equals 1 and that word is selected for dropout, `tf.random.uniform([1], maxval=num_words - 1, dtype=tf.int64)` in line 154  throws an error, `Invalid argument: Need minval < maxval, got 0 >= 0`. Return early so this line won't error and at least 1 word is always returned.

Here's a snippet of my stacktrace when I run `onmt-main train_and_eval ...`:

```
  File "/usr/local/lib/python3.6/dist-packages/tensorflow/python/client/session.py", line 1370, in _do_call
    raise type(e)(node_def, op, message)
tensorflow.python.framework.errors_impl.InvalidArgumentError: 2 root error(s) found.
  (0) Invalid argument: Need minval < maxval, got 0 >= 0
	 [[node transformer/map/while/cond/random_uniform (defined at /lib/python3.6/dist-packages/opennmt/layers/noise.py:154) ]]
	 [[transformer/map/while/cond/Merge/_1415]]
  (1) Invalid argument: Need minval < maxval, got 0 >= 0
	 [[node transformer/map/while/cond/random_uniform (defined at /lib/python3.6/dist-packages/opennmt/layers/noise.py:154) ]]
0 successful operations.
0 derived errors ignored.
```

thanks @j4th for the help on this!