### PR TITLE
Add offset to step when generating from context with language model

### DIFF
--- a/opennmt/models/language_model.py
+++ b/opennmt/models/language_model.py
@@ -94,10 +94,13 @@ class LanguageModel(Model):
       else:
         sampler = decoding.BestSampler()
 
+      def _decode_with_step_offset(ids, step, state):
+        return self._decode(ids, step + context_length[0], state)
+
       # Iteratively decode from the last decoder state.
       with tf.variable_scope(tf.get_variable_scope(), reuse=True):
         sampled_ids, sampled_length, _, _, _ = decoding.dynamic_decode(
-            self._decode,
+            _decode_with_step_offset,
             tf.squeeze(start_ids, 1),
             initial_state=state,
             sampler=sampler,


### PR DESCRIPTION
Currently, the step counter starts at zero in `decoding.dynamic_decode`, even when decoding from context with a language model, which I think may lead to positional encodings being off with Transformer language models.

I've tried to provide a fix for this here, not sure if it's the correct way to go about it.