### PR TITLE
Truncate existing prediction file before write

### DIFF
--- a/opennmt/utils/evaluator.py
+++ b/opennmt/utils/evaluator.py
@@ -125,7 +125,7 @@ class SacreBLEUScorer(Scorer):
 
   def __call__(self, labels_file, predictions_path):
     from sacrebleu import corpus_bleu
-    with open(labels_file) as ref_stream, open(predictions_path) as sys_stream:
+    with open(labels_file) as ref_stream, open(predictions_path, 'w') as sys_stream:
       bleu = corpus_bleu(sys_stream, [ref_stream])
       return bleu.score
 


### PR DESCRIPTION
In master, if the predictions file already exists, the `SacreBLEUScorer appends to this file`. I'm suggesting that the Scorer truncate the file if it already exists so that you don't have duplicate predictions.

I noticed this  when I ran ran the `omnt-main eval` again after running `omnt-main train_and_eval` earlier, and it errored out because the predictions file was twice as long as the reference.

Stacktrace snippet:
```
  File "/usr/local/lib/python3.6/dist-packages/tensorflow/python/training/monitored_session.py", line 887, in _close_internal
    h.end(self._coordinated_creator.tf_sess)
  File "/usr/local/lib/python3.6/dist-packages/opennmt/utils/hooks.py", line 266, in end
    self._post_evaluation_fn(self._current_step, self._output_path)
  File "/usr/local/lib/python3.6/dist-packages/opennmt/utils/evaluator.py", line 40, in __call__
    score = scorer(self._labels_file, predictions_path)
  File "/usr/local/lib/python3.6/dist-packages/opennmt/utils/evaluator.py", line 129, in __call__
    bleu = corpus_bleu(sys_stream, [ref_stream])
  File "/usr/local/lib/python3.6/dist-packages/sacrebleu.py", line 1365, in corpus_bleu
    raise EOFError("Source and reference streams have different lengths!")
EOFError: Source and reference streams have different lengths!
```