### PR TITLE
Allow user's to override default subword token assumption 

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -141,9 +141,9 @@ params:
   # (optional) Define the subword marker. This is useful to apply noise at the
   # word level instead of the subword level (default: ￭).
   decoding_subword_token: ￭
-  # (optional) Whether subword_token is used as a spacer (as in SentencePiece) or a joiner (as in BPE).
-  # If ``None``, will infer  directly from :obj:`subword_token`.
-  is_spacer: False
+  # (optional) Whether decoding_subword_token is used as a spacer (as in SentencePiece) or a joiner (as in BPE).
+  # If unspecified, will infer  directly from decoding_subword_token.
+  decoding_subword_token_is_spacer: false
   # (optional) Minimum length of decoded sequences, end token excluded (default: 0).
   minimum_decoding_length: 0
   # (optional) Maximum length of decoded sequences, end token excluded (default: 250).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -141,6 +141,9 @@ params:
   # (optional) Define the subword marker. This is useful to apply noise at the
   # word level instead of the subword level (default: ￭).
   decoding_subword_token: ￭
+  # (optional) Whether subword_token is used as a spacer (as in SentencePiece) or a joiner (as in BPE).
+  # If ``None``, will infer  directly from :obj:`subword_token`.
+  is_spacer: False
   # (optional) Minimum length of decoded sequences, end token excluded (default: 0).
   minimum_decoding_length: 0
   # (optional) Maximum length of decoded sequences, end token excluded (default: 250).

--- a/opennmt/models/sequence_to_sequence.py
+++ b/opennmt/models/sequence_to_sequence.py
@@ -123,7 +123,7 @@ class SequenceToSequence(model.SequenceGenerator):
       noiser = noise.WordNoiser(
           noises=[noise.WordOmission(1)],
           subword_token=self.params.get("decoding_subword_token", "￭"),
-          is_spacer=self.params.get("is_spacer"))
+          is_spacer=self.params.get("decoding_subword_token_is_spacer"))
       self.labels_inputter.set_noise(noiser, in_place=False)
 
   def build(self, input_shape):
@@ -273,7 +273,8 @@ class SequenceToSequence(model.SequenceGenerator):
           target_tokens,
           sampled_length,
           decoding_noise,
-          params.get("decoding_subword_token", "￭"))
+          params.get("decoding_subword_token", "￭"),
+          params.get("decoding_subword_token_is_spacer"))
       alignment = None  # Invalidate alignments.
 
     predictions = {

--- a/opennmt/models/sequence_to_sequence.py
+++ b/opennmt/models/sequence_to_sequence.py
@@ -122,7 +122,8 @@ class SequenceToSequence(model.SequenceGenerator):
       # https://www.aclweb.org/anthology/P19-1623
       noiser = noise.WordNoiser(
           noises=[noise.WordOmission(1)],
-          subword_token=self.params.get("decoding_subword_token", "￭"))
+          subword_token=self.params.get("decoding_subword_token", "￭"),
+          is_spacer=self.params.get("is_spacer"))
       self.labels_inputter.set_noise(noiser, in_place=False)
 
   def build(self, input_shape):
@@ -483,7 +484,7 @@ def replace_unknown_target(target_tokens,
       x=aligned_source_tokens,
       y=target_tokens)
 
-def _add_noise(tokens, lengths, params, subword_token):
+def _add_noise(tokens, lengths, params, subword_token, is_spacer=None):
   if not isinstance(params, list):
     raise ValueError("Expected a list of noise modules")
   noises = []
@@ -501,5 +502,5 @@ def _add_noise(tokens, lengths, params, subword_token):
     else:
       raise ValueError("Invalid noise type: %s" % noise_type)
     noises.append(noise_class(*args))
-  noiser = noise.WordNoiser(noises=noises, subword_token=subword_token)
+  noiser = noise.WordNoiser(noises=noises, subword_token=subword_token, is_spacer=is_spacer)
   return noiser(tokens, lengths, keep_shape=True)


### PR DESCRIPTION
## Issue
Currently user's are allowed to set the decoding_subword_token parameter to any custom value, but are not able to specify whether this should be interpreted as a joiner, or a spacer. The current approach works for standard BPE or SentencePiece but does not facilitate experimentation with custom subtokenization packages. 

## Proposed approach
In this PR we enable this option while defaulting to previous behaviour to maintain backwards compatibility.

This is necessary for our team that uses custom tokenisation and we would prefer to merge into upstream rather than maintain our own fork. I hope that the proposed change doesn't break anyone's workflow while providing extra flexibility for others as well. In case it matters, this a public mirror our [tokenisation library](https://github.com/kovalevfm/SubTokenizer)