### PR TITLE
Use custom TensorFlow Serving image to support beam search

### DIFF
--- a/examples/serving/tensorflow_serving/README.md
+++ b/examples/serving/tensorflow_serving/README.md
@@ -28,7 +28,7 @@ mv averaged-ende-export500k-v2 ende/1
 ```bash
 nvidia-docker run -d --rm -p 9000:9000 -v $PWD:/models \
   --name tensorflow_serving --entrypoint tensorflow_model_server \
-  tensorflow/serving:1.14.0-gpu \
+  opennmt/tensorflow-serving:2.0.0-gpu \
   --enable_batching=true --batching_parameters_file=/models/batching_parameters.txt \
   --port=9000 --model_base_path=/models/ende --model_name=ende
 ```
@@ -64,3 +64,11 @@ Depending on your production requirements, you might need to build a simple prox
 * apply tokenization and detokenization
 
 For example, take a look at the OpenNMT-tf integration in the project [nmt-wizard-docker](https://github.com/OpenNMT/nmt-wizard-docker/blob/master/frameworks/opennmt_tf/entrypoint.py) which wraps a TensorFlow serving instance with a custom processing layer and REST API. It is possible to use exported OpenNMT-tf with nmt-wizard-docker with the [following approach](https://github.com/OpenNMT/nmt-wizard-docker/issues/46#issuecomment-456795844).
+
+## Custom TensorFlow Serving image
+
+The Docker image [`opennmt/tensorflow-serving`](https://hub.docker.com/r/opennmt/tensorflow-serving) includes additional TensorFlow ops used by OpenNMT-tf. For example, beam search decoding uses the op [`Addons>GatherTree`](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/custom_ops/seq2seq/cc/ops/beam_search_ops.cc) which is not available in standard TensorFlow Serving.
+
+This custom image is considered temporary. The concerned ops are expected to be included in an official or community-supported build of TensorFlow Serving in the future.
+
+See the `docker/` directory for more details.

--- a/examples/serving/tensorflow_serving/docker/build_tensorflow_serving.sh
+++ b/examples/serving/tensorflow_serving/docker/build_tensorflow_serving.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+if [ $# -eq 0 ]; then
+    echo "usage: $0 X.Y.Z"
+    exit 1
+fi
+
+set -e
+
+VERSION=$1
+PUSH=${2:-0}
+BUILD_OPTIONS="--copt=-mavx"
+
+curl -fSsL -O https://github.com/tensorflow/serving/archive/$VERSION.tar.gz
+tar xf $VERSION.tar.gz
+rm $VERSION.tar.gz
+cp *.patch serving-$VERSION
+cd serving-$VERSION
+patch -p1 < serving_dockerfile.patch
+
+docker build -t opennmt/tensorflow-serving:$VERSION-devel \
+       --build-arg TF_SERVING_VERSION_GIT_BRANCH=$VERSION \
+       --build-arg TF_SERVING_BUILD_OPTIONS=$BUILD_OPTIONS \
+       -f tensorflow_serving/tools/docker/Dockerfile.devel .
+docker build -t opennmt/tensorflow-serving:$VERSION \
+       --build-arg TF_SERVING_BUILD_IMAGE=opennmt/tensorflow-serving:$VERSION-devel \
+       -f tensorflow_serving/tools/docker/Dockerfile .
+if [ $PUSH -eq 1 ]; then
+    docker push opennmt/tensorflow-serving:$VERSION
+fi
+
+docker build -t opennmt/tensorflow-serving:$VERSION-devel-gpu \
+       --build-arg TF_SERVING_VERSION_GIT_BRANCH=$VERSION \
+       --build-arg TF_SERVING_BUILD_OPTIONS=$BUILD_OPTIONS \
+       -f tensorflow_serving/tools/docker/Dockerfile.devel-gpu .
+docker build -t opennmt/tensorflow-serving:$VERSION-gpu \
+       --build-arg TF_SERVING_BUILD_IMAGE=opennmt/tensorflow-serving:$VERSION-devel-gpu \
+       -f tensorflow_serving/tools/docker/Dockerfile.gpu .
+if [ $PUSH -eq 1 ]; then
+    docker push opennmt/tensorflow-serving:$VERSION-gpu
+fi
+
+cd ..
+rm -r serving-$VERSION

--- a/examples/serving/tensorflow_serving/docker/serving_dockerfile.patch
+++ b/examples/serving/tensorflow_serving/docker/serving_dockerfile.patch
@@ -1,0 +1,27 @@
+diff --git a/tensorflow_serving/tools/docker/Dockerfile.devel b/tensorflow_serving/tools/docker/Dockerfile.devel
+index 36af5e9..fd95470 100644
+--- a/tensorflow_serving/tools/docker/Dockerfile.devel
++++ b/tensorflow_serving/tools/docker/Dockerfile.devel
+@@ -77,7 +77,8 @@ WORKDIR /tensorflow-serving
+ RUN git clone --branch=${TF_SERVING_VERSION_GIT_BRANCH} https://github.com/tensorflow/serving . && \
+     git remote add upstream https://github.com/tensorflow/serving.git && \
+     if [ "${TF_SERVING_VERSION_GIT_COMMIT}" != "head" ]; then git checkout ${TF_SERVING_VERSION_GIT_COMMIT} ; fi
+-
++COPY tfaddons_beam_search_ops.patch .
++RUN patch -p1 < tfaddons_beam_search_ops.patch
+ 
+ FROM base_build as binary_build
+ # Build, and install TensorFlow Serving
+diff --git a/tensorflow_serving/tools/docker/Dockerfile.devel-gpu b/tensorflow_serving/tools/docker/Dockerfile.devel-gpu
+index e545391..77ad360 100644
+--- a/tensorflow_serving/tools/docker/Dockerfile.devel-gpu
++++ b/tensorflow_serving/tools/docker/Dockerfile.devel-gpu
+@@ -132,6 +132,8 @@ WORKDIR /tensorflow-serving
+ RUN git clone --branch=${TF_SERVING_VERSION_GIT_BRANCH} https://github.com/tensorflow/serving . && \
+     git remote add upstream https://github.com/tensorflow/serving.git && \
+     if [ "${TF_SERVING_VERSION_GIT_COMMIT}" != "head" ]; then git checkout ${TF_SERVING_VERSION_GIT_COMMIT} ; fi
++COPY tfaddons_beam_search_ops.patch .
++RUN patch -p1 < tfaddons_beam_search_ops.patch
+ 
+ FROM base_build as binary_build
+ # Build, and install TensorFlow Serving

--- a/examples/serving/tensorflow_serving/docker/tfaddons_beam_search_ops.patch
+++ b/examples/serving/tensorflow_serving/docker/tfaddons_beam_search_ops.patch
@@ -1,0 +1,99 @@
+diff --git a/tensorflow_serving/model_servers/BUILD b/tensorflow_serving/model_servers/BUILD
+index d4940bf..f62a648 100644
+--- a/tensorflow_serving/model_servers/BUILD
++++ b/tensorflow_serving/model_servers/BUILD
+@@ -303,6 +303,8 @@ SUPPORTED_TENSORFLOW_OPS = if_v2([]) + if_not_v2([
+     "@org_tensorflow_text//tensorflow_text:unicode_script_tokenizer_cc",
+     "@org_tensorflow_text//tensorflow_text:whitespace_tokenizer_cc",
+     "@org_tensorflow_text//tensorflow_text:wordpiece_tokenizer_cc",
++] + [
++    "@org_tensorflow_addons//tensorflow_addons/custom_ops/seq2seq:_beam_search_ops.so",
+ ]
+ 
+ TENSORFLOW_DEPS = [
+diff --git a/tensorflow_serving/workspace.bzl b/tensorflow_serving/workspace.bzl
+index ba8725b..c49667b 100644
+--- a/tensorflow_serving/workspace.bzl
++++ b/tensorflow_serving/workspace.bzl
+@@ -70,3 +70,15 @@ def tf_serving_workspace():
+         patches = ["@//third_party/tf_text:tftext.patch"],
+         patch_args = ["-p1"],
+     )
++
++    # ===== TF.Addons dependencies
++    http_archive(
++        name = "org_tensorflow_addons",
++        sha256 = "b672c13a5dbe3be5d5aed28586d702d26b3227d9bdd52c052fd6cba0774194eb",
++        strip_prefix = "addons-8a49f91483d67e85c8e8d4f67cd6aea8c45cd2b8",
++        urls = [
++            "https://github.com/tensorflow/addons/archive/8a49f91483d67e85c8e8d4f67cd6aea8c45cd2b8.zip",
++        ],
++        patches = ["@//third_party/tf_addons:tfaddons.patch"],
++        patch_args = ["-p1"],
++    )
+diff --git a/third_party/tf_addons/BUILD b/third_party/tf_addons/BUILD
+new file mode 100644
+index 0000000..e69de29
+diff --git a/third_party/tf_addons/tfaddons.patch b/third_party/tf_addons/tfaddons.patch
+new file mode 100644
+index 0000000..3c90e99
+--- /dev/null
++++ b/third_party/tf_addons/tfaddons.patch
+@@ -0,0 +1,56 @@
++--- a/tensorflow_addons/tensorflow_addons.bzl
+++++ b/tensorflow_addons/tensorflow_addons.bzl
++@@ -1,6 +1,3 @@
++-load("@local_config_tf//:build_defs.bzl", "D_GLIBCXX_USE_CXX11_ABI")
++-load("@local_config_cuda//cuda:build_defs.bzl", "if_cuda_is_configured", "if_cuda")
++-
++ def custom_op_library(
++         name,
++         srcs = [],
++@@ -10,42 +7,17 @@ def custom_op_library(
++         copts = [],
++         **kwargs):
++     deps = deps + [
++-        "@local_config_tf//:libtensorflow_framework",
++-        "@local_config_tf//:tf_header_lib",
+++        "@org_tensorflow//tensorflow/core:tensorflow_opensource",
++     ]
++ 
++-    if cuda_srcs:
++-        copts = copts + if_cuda(["-DGOOGLE_CUDA=1"])
++-        cuda_copts = copts + if_cuda_is_configured([
++-            "-x cuda",
++-            "-nvcc_options=relaxed-constexpr",
++-            "-nvcc_options=ftz=true",
++-        ])
++-        cuda_deps = deps + if_cuda_is_configured(cuda_deps) + if_cuda_is_configured([
++-            "@local_config_cuda//cuda:cuda_headers",
++-            "@local_config_cuda//cuda:cudart_static",
++-        ])
++-        basename = name.split(".")[0]
++-        native.cc_library(
++-            name = basename + "_gpu",
++-            srcs = cuda_srcs,
++-            deps = cuda_deps,
++-            copts = cuda_copts,
++-            alwayslink = 1,
++-            **kwargs
++-        )
++-        deps = deps + if_cuda_is_configured([":" + basename + "_gpu"])
++-
++     copts = copts + [
++         "-pthread",
++-        "-std=c++11",
++-        D_GLIBCXX_USE_CXX11_ABI,
++     ]
++ 
++-    native.cc_binary(
+++    native.cc_library(
++         name = name,
++         srcs = srcs,
++         copts = copts,
++-        linkshared = 1,
+++        alwayslink = 1,
++         deps = deps,
++         **kwargs
++     )
+\ No newline at end of file

--- a/examples/serving/tensorflow_serving/requirements.txt
+++ b/examples/serving/tensorflow_serving/requirements.txt
@@ -1,2 +1,2 @@
 pyonmttok>=1.14.0,<2
-tensorflow-serving-api==1.14.0
+tensorflow-serving-api==2.0.0


### PR DESCRIPTION
The `Addons>GatherTree` op is currently not included in the official TensorFlow Serving builds. This custom image should unblock users that are already looking to use Serving with OpenNMT-tf v2 models.