### PR TITLE
Make injection of special sequence tokens (<s>, </s>) configurable

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,6 +59,16 @@ data:
     case_insensitive: True
     trainable: False
 
+  # (optional) For language models, configure sequence control tokens (usually
+  # represented as <s> and </s>). For example, enabling "start" and disabling "end"
+  # allows nonconditional and unbounded generation (default: start=false, end=true).
+  #
+  # Advanced users could also configure this parameter for seq2seq models with e.g.
+  # source_sequence_controls and target_sequence_controls.
+  sequence_controls:
+    start: false
+    end: true
+
   # (optional) For sequence tagging tasks, the tagging scheme that is used (e.g. BIOES).
   # For supported schemes, additional evaluation metrics could be computed such as
   # precision, recall, etc. (accepted values: bioes; default: null).

--- a/opennmt/inputters/__init__.py
+++ b/opennmt/inputters/__init__.py
@@ -19,4 +19,5 @@ from opennmt.inputters.text_inputter import CharConvEmbedder
 from opennmt.inputters.text_inputter import CharRNNEmbedder
 from opennmt.inputters.text_inputter import TextInputter
 from opennmt.inputters.text_inputter import WordEmbedder
+from opennmt.inputters.text_inputter import add_sequence_controls
 from opennmt.inputters.text_inputter import load_pretrained_embeddings

--- a/opennmt/tests/test_util.py
+++ b/opennmt/tests/test_util.py
@@ -17,6 +17,16 @@ def make_data_file(path, lines):
       data.write("%s\n" % line)
   return path
 
+def make_vocab(path, tokens):
+  vocabulary = vocab.Vocab(special_tokens=[
+      constants.PADDING_TOKEN,
+      constants.START_OF_SENTENCE_TOKEN,
+      constants.END_OF_SENTENCE_TOKEN])
+  for token in tokens:
+    vocabulary.add(token)
+  vocabulary.serialize(path)
+  return path
+
 def make_vocab_from_file(path, data_file):
   vocabulary = vocab.Vocab(special_tokens=[
       constants.PADDING_TOKEN,


### PR DESCRIPTION
This is especially needed for language models where these special tokens may or may not be wanted depending on the task requirement.

For example, to allow nonconditional and unbounded generation of text, one would enable `<s>` but disable `</s>`. However, to generate a fixed sequence from a prefix/context, one would disable `<s>` but enable `</s>`.

This change also enables this configuration for seq2seq models (source and target). There could be reasons to want `</s>` at the end of the source sequences.