### PR TITLE
Fix batch size in multiple GPU training

### DIFF
--- a/opennmt/runner.py
+++ b/opennmt/runner.py
@@ -155,6 +155,7 @@ class Runner(object):
         data_config.get("train_labels_file"),
         train_config["batch_size"],
         batch_type=batch_type,
+        batch_multiplier=num_devices,
         batch_size_multiple=batch_size_multiple,
         shuffle_buffer_size=train_config["sample_buffer_size"],
         length_bucket_width=train_config["length_bucket_width"],
@@ -172,6 +173,8 @@ class Runner(object):
       devices = None
     else:
       devices = tf.config.experimental.list_logical_devices(device_type="GPU")
+      if not devices:
+        devices = tf.config.experimental.list_logical_devices(device_type="CPU")
       if len(devices) < num_devices:
         raise ValueError("Requested %d devices but only %d are visible" % (
             num_devices, len(devices)))


### PR DESCRIPTION
The documentation of `experimental_distribute_dataset` says:

> We will assume that the input dataset is batched by the global batch size. With this assumption, we will make a best effort to divide each batch across all the replicas (one or more workers).

So we need to scale the batch size by the requested number of training devices.