### PR TITLE
Fix retrieval of variable from object-based name in checkpoint averaging

### DIFF
--- a/opennmt/tests/checkpoint_test.py
+++ b/opennmt/tests/checkpoint_test.py
@@ -5,11 +5,18 @@ import tensorflow as tf
 from opennmt.utils import checkpoint as checkpoint_util
 
 
+class _CustomDense(tf.keras.layers.Dense):
+
+  def add_weight(self, name, *args, **kwargs):
+    # This is to test the case where the variable name is different than the attribute name.
+    name += "_1"
+    return super(_CustomDense, self).add_weight(name, *args, **kwargs)
+
 class _DummyModel(tf.keras.layers.Layer):
 
   def __init__(self):
     super(_DummyModel, self).__init__()
-    self.layers = [tf.keras.layers.Dense(20), tf.keras.layers.Dense(20)]
+    self.layers = [tf.keras.layers.Dense(20), _CustomDense(20)]
 
   def call(self, x):
     for layer in self.layers:

--- a/opennmt/tests/misc_test.py
+++ b/opennmt/tests/misc_test.py
@@ -19,8 +19,14 @@ class MiscTest(tf.test.TestCase):
         self.layers = [Layer()]
 
     model = Model()
-    variable_name = misc.get_variable_name(model.layers[0].variable, model)
-    self.assertEqual(variable_name, "model/layers/0/variable/.ATTRIBUTES/VARIABLE_VALUE")
+    variable = model.layers[0].variable
+    expected_name = "model/layers/0/variable/.ATTRIBUTES/VARIABLE_VALUE"
+    variable_name = misc.get_variable_name(variable, model)
+    self.assertEqual(variable_name, expected_name)
+
+    variables_to_names, names_to_variables = misc.get_variables_name_mapping(model, root_key="model")
+    self.assertDictEqual(variables_to_names, {variable.experimental_ref(): expected_name})
+    self.assertDictEqual(names_to_variables, {expected_name: variable})
 
   def testSetDropout(self):
 

--- a/opennmt/utils/checkpoint.py
+++ b/opennmt/utils/checkpoint.py
@@ -166,6 +166,9 @@ def average_checkpoints(model_dir,
   num_checkpoints = len(checkpoints_path)
   last_step = int(checkpoints_path[-1].split("-")[-1])
 
+  # Get a map from variable names in the checkpoint to variables in the model.
+  _, names_to_variables = misc.get_variables_name_mapping(model, root_key=model_key)
+
   tf.get_logger().info("Averaging %d checkpoints...", num_checkpoints)
   for i, checkpoint_path in enumerate(reversed(checkpoints_path)):
     tf.get_logger().info("Reading checkpoint %s...", checkpoint_path)
@@ -178,8 +181,7 @@ def average_checkpoints(model_dir,
       for path in six.iterkeys(reader.get_variable_to_shape_map()):
         if not path.startswith(model_key) or ".OPTIMIZER_SLOT" in path:
           continue
-        variable_path = path.replace("/.ATTRIBUTES/VARIABLE_VALUE", "")
-        variable = misc.index_structure(trackables, variable_path)
+        variable = names_to_variables[path]
         value = reader.get_tensor(path)
         variable.assign_add(value / num_checkpoints)
 


### PR DESCRIPTION
The previous logic incorrectly assumes how TensorFlow generates variables name in the checkpoint. We now invoke a TensorFlow API to deduce the mapping between variables and their name in the checkpoint.