### PR TITLE
Do not use device_map to get the replica variable

### DIFF
--- a/opennmt/optimizers/utils.py
+++ b/opennmt/optimizers/utils.py
@@ -105,8 +105,9 @@ class GradientAccumulator(object):
       replica_context = tf.distribute.get_replica_context()
       if replica_context is None:
         return self._gradients
-      return (
-          gradient.device_map.select_for_current_replica(gradient.values, replica_context)
-          for gradient in self._gradients)
+      replica_id = replica_context.replica_id_in_sync_group
+      if not isinstance(replica_id, int):
+        replica_id = tf.get_static_value(replica_id)
+      return (gradient.values[replica_id] for gradient in self._gradients)
     else:
       return self._gradients


### PR DESCRIPTION
This property was removed in https://github.com/tensorflow/tensorflow/commit/d02266ff21959e08b875cfb92477e0e865140aaa.