### PR TITLE
Fix reporting loss bug

### DIFF
--- a/opennmt/training.py
+++ b/opennmt/training.py
@@ -208,7 +208,7 @@ class Trainer(object):
     loss = self._model.compute_loss(outputs, target, training=True)
     if isinstance(loss, tuple):
       training_loss = loss[0] / loss[1]
-      reported_loss = loss[0] / loss[2]
+      reported_loss = loss[0] / loss[2] if len(loss) > 2 else training_loss
     else:
       training_loss, reported_loss = loss, loss
     variables = self._model.trainable_variables


### PR DESCRIPTION
https://github.com/OpenNMT/OpenNMT-tf/blob/master/opennmt/models/sequence_classifier.py#L61

In SequenceClassifier, the compute_loss returns a tuple of length 2.