### PR TITLE
Make dataset cardinality a multiple of the number of replicas

### DIFF
--- a/opennmt/data/__init__.py
+++ b/opennmt/data/__init__.py
@@ -6,6 +6,7 @@ from opennmt.data.dataset import filter_examples_by_length
 from opennmt.data.dataset import filter_irregular_batches
 from opennmt.data.dataset import get_dataset_size
 from opennmt.data.dataset import inference_pipeline
+from opennmt.data.dataset import make_cardinality_multiple_of
 from opennmt.data.dataset import random_shard
 from opennmt.data.dataset import shuffle_dataset
 from opennmt.data.dataset import training_pipeline

--- a/opennmt/inputters/inputter.py
+++ b/opennmt/inputters/inputter.py
@@ -490,7 +490,8 @@ class ExampleInputter(ParallelInputter):
                             num_shards=1,
                             shard_index=0,
                             num_threads=4,
-                            prefetch_buffer_size=None):
+                            prefetch_buffer_size=None,
+                            cardinality_multiple=1):
     """Builds a dataset to be used for training. It supports the full training
     pipeline, including:
 
@@ -525,6 +526,8 @@ class ExampleInputter(ParallelInputter):
       num_threads: The number of elements processed in parallel.
       prefetch_buffer_size: The number of batches to prefetch asynchronously. If
         ``None``, use an automatically tuned value.
+      cardinality_multiple: Ensure that the dataset cardinality is a multiple of
+        this value when :obj:`single_pass` is ``True``.
 
     Returns:
       A ``tf.data.Dataset``.
@@ -550,5 +553,6 @@ class ExampleInputter(ParallelInputter):
         shard_index=shard_index,
         num_threads=num_threads,
         shuffle_buffer_size=shuffle_buffer_size,
-        prefetch_buffer_size=prefetch_buffer_size))
+        prefetch_buffer_size=prefetch_buffer_size,
+        cardinality_multiple=cardinality_multiple))
     return dataset

--- a/opennmt/tests/dataset_test.py
+++ b/opennmt/tests/dataset_test.py
@@ -1,12 +1,14 @@
 import os
 
+from parameterized import parameterized
+
 import tensorflow as tf
 
 from opennmt.data import dataset as dataset_util
 from opennmt.tests import test_util
 
 
-class DataTest(tf.test.TestCase):
+class DatasetTest(tf.test.TestCase):
 
   def testDatasetSize(self):
     path = test_util.make_data_file(
@@ -27,6 +29,16 @@ class DataTest(tf.test.TestCase):
     self.assertEqual(batch_size, single_element["x"].shape[0])
     with self.assertRaises(StopIteration):
       next(iterator)
+
+  @parameterized.expand([
+      [11, 5, 15],
+      [10, 5, 10],
+      [5, 20, 20]
+  ])
+  def testMakeCardinalityMultipleOf(self, dataset_size, divisor, expected_size):
+    dataset = tf.data.Dataset.range(dataset_size)
+    dataset = dataset.apply(dataset_util.make_cardinality_multiple_of(divisor))
+    self.assertLen(list(iter(dataset)), expected_size)
 
   def testRandomShard(self):
     dataset_size = 42


### PR DESCRIPTION
This handles the case of a finite dataset more nicely. This change also prepares the dataset sharding for multi-worker training.