### PR TITLE
Export vocabularies as assets by default

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,6 +41,10 @@ data:
   source_vocabulary: data/toy-ende/src-vocab.txt
   target_vocabulary: data/toy-ende/tgt-vocab.txt
 
+  # (optional) During export save the vocabularies as model assets, otherwise embed
+  # them in the graph itself (default: True).
+  export_vocabulary_assets: True
+
   # (optional) Tokenization configuration (or path to a configuration file).
   # See also: https://github.com/OpenNMT/Tokenizer/blob/master/docs/options.md
   source_tokenization:

--- a/opennmt/inputters/text_inputter.py
+++ b/opennmt/inputters/text_inputter.py
@@ -207,18 +207,35 @@ def _get_field(config, key, prefix=None, default=None, required=False):
     raise ValueError("Missing field '%s' in the data configuration" % key)
   return value
 
-def _create_tokens_to_ids_table(tokens, ids, num_oov_buckets):
-  # TODO: consider reverting back to TextFileInitializer when this change is released:
-  # https://github.com/tensorflow/tensorflow/pull/32773
-  initializer = tf.lookup.KeyValueTensorInitializer(tokens, ids)
-  if num_oov_buckets > 0:
-    return tf.lookup.StaticVocabularyTable(initializer, num_oov_buckets)
+def _create_vocabulary_tables(vocabulary_file, num_oov_buckets, as_asset=True):
+  vocabulary = Vocab.from_file(vocabulary_file)
+  vocabulary_size = len(vocabulary)
+  if as_asset:
+    tokens_to_ids_initializer = tf.lookup.TextFileInitializer(
+        vocabulary_file,
+        tf.string,
+        tf.lookup.TextFileIndex.WHOLE_LINE,
+        tf.int64,
+        tf.lookup.TextFileIndex.LINE_NUMBER,
+        vocab_size=vocabulary_size)
+    ids_to_tokens_initializer = tf.lookup.TextFileInitializer(
+        vocabulary_file,
+        tf.int64,
+        tf.lookup.TextFileIndex.LINE_NUMBER,
+        tf.string,
+        tf.lookup.TextFileIndex.WHOLE_LINE,
+        vocab_size=vocabulary_size)
   else:
-    return tf.lookup.StaticHashTable(initializer, 0)
-
-def _create_ids_to_tokens_table(ids, tokens):
-  initializer = tf.lookup.KeyValueTensorInitializer(ids, tokens)
-  return tf.lookup.StaticHashTable(initializer, constants.UNKNOWN_TOKEN)
+    tokens = tf.constant(vocabulary.words, dtype=tf.string)
+    ids = tf.constant(list(range(vocabulary_size)), dtype=tf.int64)
+    tokens_to_ids_initializer = tf.lookup.KeyValueTensorInitializer(tokens, ids)
+    ids_to_tokens_initializer = tf.lookup.KeyValueTensorInitializer(ids, tokens)
+  if num_oov_buckets > 0:
+    tokens_to_ids = tf.lookup.StaticVocabularyTable(tokens_to_ids_initializer, num_oov_buckets)
+  else:
+    tokens_to_ids = tf.lookup.StaticHashTable(tokens_to_ids_initializer, 0)
+  ids_to_tokens = tf.lookup.StaticHashTable(ids_to_tokens_initializer, constants.UNKNOWN_TOKEN)
+  return vocabulary_size + num_oov_buckets, tokens_to_ids, ids_to_tokens
 
 
 class TextInputter(Inputter):
@@ -234,12 +251,10 @@ class TextInputter(Inputter):
   def initialize(self, data_config, asset_prefix=""):
     self.vocabulary_file = _get_field(
         data_config, "vocabulary", prefix=asset_prefix, required=True)
-    vocabulary = Vocab.from_file(self.vocabulary_file)
-    self.vocabulary_size = len(vocabulary) + self.num_oov_buckets
-    tokens = tf.constant(vocabulary.words, dtype=tf.string)
-    ids = tf.constant(list(range(len(vocabulary))), dtype=tf.int64)
-    self.tokens_to_ids = _create_tokens_to_ids_table(tokens, ids, self.num_oov_buckets)
-    self.ids_to_tokens = _create_ids_to_tokens_table(ids, tokens)
+    self.vocabulary_size, self.tokens_to_ids, self.ids_to_tokens = _create_vocabulary_tables(
+        self.vocabulary_file,
+        self.num_oov_buckets,
+        as_asset=data_config.get("export_vocabulary_assets", True))
     tokenizer_config = _get_field(data_config, "tokenization", prefix=asset_prefix)
     self.tokenizer = tokenizers.make_tokenizer(tokenizer_config)
 


### PR DESCRIPTION
This was the behavior in V1 but was temporarily disabled in V2 due to a TensorFlow bug.

A new export_vocabulary_assets parameters can be used to include vocabularies in the graph itself (behavior in V2 before this commit).

Closes #516.