### PR TITLE
[WIP] Convolutional Self-Attention Networks

### DIFF
--- a/opennmt/encoders/self_attention_encoder.py
+++ b/opennmt/encoders/self_attention_encoder.py
@@ -81,7 +81,8 @@ class SelfAttentionEncoder(Encoder):
             maximum_relative_position=maximum_relative_position,
             attention_span=attention_span,
             num_attended_heads=num_attended_heads)
-        for _ in range(num_constrained_layers)] + [
+        for _ in range(num_constrained_layers)]
+    self.layers += [
         transformer.SelfAttentionEncoderLayer(
             num_units,
             num_heads,

--- a/opennmt/encoders/self_attention_encoder.py
+++ b/opennmt/encoders/self_attention_encoder.py
@@ -27,6 +27,7 @@ class SelfAttentionEncoder(Encoder):
                position_encoder_class=SinusoidalPositionEncoder,
                maximum_relative_position=None,
                attention_span=None,
+               num_attended_heads=1,
                **kwargs):
     """Initializes the parameters of the encoder.
 
@@ -49,6 +50,10 @@ class SelfAttentionEncoder(Encoder):
         (from https://arxiv.org/abs/1803.02155).
       attention_span: Maximum relative position to attend to
         (from https://arxiv.org/abs/1904.03107).
+      num_attended_heads: How many heads should be attended. Defaults to 1
+        as each head only attends to itself in vanilla Transformer. Increase to
+        an odd number < `num_heads` to also model head interaction.
+        (from ttps://arxiv.org/abs/1904.03107).
       **kwargs: Additional layer arguments.
     """
     super(SelfAttentionEncoder, self).__init__(**kwargs)
@@ -74,7 +79,8 @@ class SelfAttentionEncoder(Encoder):
             ffn_dropout=ffn_dropout,
             ffn_activation=ffn_activation,
             maximum_relative_position=maximum_relative_position,
-            attention_span=attention_span)
+            attention_span=attention_span,
+            num_attended_heads=num_attended_heads)
         for i in range(num_constrained_layers)] + [
         transformer.SelfAttentionEncoderLayer(
             num_units,

--- a/opennmt/encoders/self_attention_encoder.py
+++ b/opennmt/encoders/self_attention_encoder.py
@@ -81,7 +81,7 @@ class SelfAttentionEncoder(Encoder):
             maximum_relative_position=maximum_relative_position,
             attention_span=attention_span,
             num_attended_heads=num_attended_heads)
-        for i in range(num_constrained_layers)] + [
+        for _ in range(num_constrained_layers)] + [
         transformer.SelfAttentionEncoderLayer(
             num_units,
             num_heads,
@@ -91,7 +91,7 @@ class SelfAttentionEncoder(Encoder):
             ffn_dropout=ffn_dropout,
             ffn_activation=ffn_activation,
             maximum_relative_position=maximum_relative_position)
-        for i in range(num_unconstrained_layers)]
+        for _ in range(num_unconstrained_layers)]
 
   def call(self, inputs, sequence_length=None, training=None):
     inputs *= self.num_units**0.5

--- a/opennmt/layers/transformer.py
+++ b/opennmt/layers/transformer.py
@@ -160,6 +160,7 @@ class MultiHeadAttention(tf.keras.layers.Layer):
                return_attention=False,
                maximum_relative_position=None,
                attention_span=None,
+               num_attended_heads=1,
                **kwargs):
     """Initializes this layer.
 
@@ -173,6 +174,10 @@ class MultiHeadAttention(tf.keras.layers.Layer):
         (from https://arxiv.org/abs/1803.02155).
       attention_span: Maximum relative position to attend to
         (from https://arxiv.org/abs/1904.03107).
+      num_attended_heads: How many heads should be attended. Defaults to 1
+        as each head only attends to itself in vanilla Transformer. Increase to
+        an odd number < `num_heads` to also model head interaction.
+        (from ttps://arxiv.org/abs/1904.03107).
       kwargs: Additional layer arguments.
     """
     super(MultiHeadAttention, self).__init__(**kwargs)
@@ -189,6 +194,9 @@ class MultiHeadAttention(tf.keras.layers.Layer):
     self.return_attention = return_attention
     self.maximum_relative_position = maximum_relative_position
     self.attention_span = attention_span
+    if num_attended_heads % 2 == 0:
+      raise ValueError("Number heads attended must be odd to guarantee symmetry.")
+    self.num_attended_heads = num_attended_heads
 
   def map_v1_weights(self, weights):
     # V1 used conv1d layers that have a leading dimensions.
@@ -284,16 +292,31 @@ class MultiHeadAttention(tf.keras.layers.Layer):
 
     cache = (keys, values)
 
+    # Express 2D Convolution as an expanded matrix multiplication.
+    # Does nothing if `num_heads_attended == 1`
+    max_shift = int((self.num_attended_heads - 1) / 2)
+
+    def conv_itself(x):
+      rolls = [tf.roll(x, shift=shift, axis=1) for shift in range(max_shift, -(max_shift + 1), -1)]
+      return tf.concat(rolls, axis=2)
+
+    keys = conv_itself(keys)
+    values = conv_itself(values)
+
     # Dot product attention.
     dot = tf.matmul(queries, keys, transpose_b=True)
 
     if self.attention_span is not None:
       if memory is not None:
         raise ValueError("Attention Span only supports self-attention")
-      maximum_length = tf.shape(keys)[2]
+      batch_size = tf.shape(queries)[0]
+      maximum_length = tf.shape(queries)[2]
       attention_span = tf.math.minimum(self.attention_span, maximum_length)
-      span_mask = tf.linalg.band_part(
-          tf.ones(tf.shape(dot)), attention_span, attention_span)
+      head_span_mask = tf.linalg.band_part(
+          tf.ones([batch_size, self.num_heads, maximum_length, maximum_length]),
+          attention_span,
+          attention_span)
+      span_mask = tf.concat([head_span_mask] * self.num_attended_heads, axis=3)
       span_mask = tf.cast(span_mask, tf.float32)
       dot = tf.cast(tf.cast(dot, tf.float32) * span_mask + ((1.0 - span_mask) * tf.float32.min), dot.dtype)
 
@@ -304,6 +327,7 @@ class MultiHeadAttention(tf.keras.layers.Layer):
       if mask.shape.rank == 2:
         mask = tf.expand_dims(mask, 1)  # Broadcast on time dimension.
       mask = tf.expand_dims(mask, 1)  # Broadcast on head dimension.
+      mask = tf.concat([mask] * self.num_attended_heads, axis=3) # Replicate on time dimension.
       dot = tf.cast(tf.cast(dot, tf.float32) * mask + ((1.0 - mask) * tf.float32.min), dot.dtype)
     attn = tf.cast(tf.nn.softmax(tf.cast(dot, tf.float32)), dot.dtype)
     drop_attn = common.dropout(attn, self.dropout, training=training)
@@ -364,6 +388,7 @@ class SelfAttentionEncoderLayer(tf.keras.layers.Layer):
                ffn_activation=tf.nn.relu,
                maximum_relative_position=None,
                attention_span=None,
+               num_attended_heads=1,
                **kwargs):
     """Initializes the layer.
 
@@ -382,6 +407,10 @@ class SelfAttentionEncoderLayer(tf.keras.layers.Layer):
         (from https://arxiv.org/abs/1803.02155).
       attention_span: Maximum relative position to attend to
         (from https://arxiv.org/abs/1904.03107).
+      num_attended_heads: How many heads should be attended. Defaults to 1
+        as each head only attends to itself in vanilla Transformer. Increase to
+        an odd number < `num_heads` to also model head interaction.
+        (from ttps://arxiv.org/abs/1904.03107).
       kwargs: Additional layer arguments.
     """
     super(SelfAttentionEncoderLayer, self).__init__(**kwargs)
@@ -390,7 +419,8 @@ class SelfAttentionEncoderLayer(tf.keras.layers.Layer):
         num_units,
         dropout=attention_dropout,
         maximum_relative_position=maximum_relative_position,
-        attention_span=attention_span)
+        attention_span=attention_span,
+        num_attended_heads=num_attended_heads)
     self.self_attention = TransformerLayerWrapper(
         self.self_attention, dropout)
     self.ffn = FeedForwardNetwork(

--- a/opennmt/layers/transformer.py
+++ b/opennmt/layers/transformer.py
@@ -288,10 +288,12 @@ class MultiHeadAttention(tf.keras.layers.Layer):
     dot = tf.matmul(queries, keys, transpose_b=True)
 
     if self.attention_span is not None:
-      batch_size = keys.shape[0]
-      maximum_length = keys.shape[1]
+      if memory is not None:
+        raise ValueError("Attention Span only supports self-attention")
+      maximum_length = tf.shape(keys)[2]
+      attention_span = tf.math.minimum(self.attention_span, maximum_length)
       span_mask = tf.linalg.band_part(
-          tf.ones(dot.shape), self.attention_span, self.attention_span)
+          tf.ones(tf.shape(dot)), attention_span, attention_span)
       span_mask = tf.cast(span_mask, tf.float32)
       dot = tf.cast(tf.cast(dot, tf.float32) * span_mask + ((1.0 - span_mask) * tf.float32.min), dot.dtype)
 

--- a/opennmt/layers/transformer.py
+++ b/opennmt/layers/transformer.py
@@ -318,7 +318,8 @@ class MultiHeadAttention(tf.keras.layers.Layer):
           attention_span)
       span_mask = tf.concat([head_span_mask] * self.num_attended_heads, axis=3)
       span_mask = tf.cast(span_mask, tf.float32)
-      dot = tf.cast(tf.cast(dot, tf.float32) * span_mask + ((1.0 - span_mask) * tf.float32.min), dot.dtype)
+      dot = tf.cast(
+          tf.cast(dot, tf.float32) * span_mask + ((1.0 - span_mask) * tf.float32.min), dot.dtype)
 
     if relative_repr_keys is not None:
       dot += matmul_with_relative_representations(queries, relative_repr_keys, transpose_b=True)

--- a/opennmt/models/__init__.py
+++ b/opennmt/models/__init__.py
@@ -8,6 +8,8 @@ from opennmt.models.catalog import Transformer as TransformerBase
 from opennmt.models.catalog import TransformerBig
 from opennmt.models.catalog import TransformerBigRelative
 from opennmt.models.catalog import TransformerRelative
+from opennmt.models.catalog import TransformerConv
+from opennmt.models.catalog import TransformerBigConv
 
 from opennmt.models.language_model import LanguageModel
 from opennmt.models.language_model import LanguageModelInputter

--- a/opennmt/models/catalog.py
+++ b/opennmt/models/catalog.py
@@ -235,7 +235,12 @@ class _DefaultTransformer(transformer.Transformer):
     else:
       position_encoder_class = layers.SinusoidalPositionEncoder
       maximum_relative_position = None
-    attention_span = 5 if conv else None
+    if conv:
+      attention_span = 5
+      num_attended_heads = 3
+    else:
+      attention_span = None
+      num_attended_heads = 1
 
     super(_DefaultTransformer, self).__init__(
         source_inputter=inputters.WordEmbedder(embedding_size=num_units),
@@ -249,7 +254,8 @@ class _DefaultTransformer(transformer.Transformer):
         ffn_dropout=0.1,
         position_encoder_class=position_encoder_class,
         maximum_relative_position=maximum_relative_position,
-        attention_span=attention_span)
+        attention_span=attention_span,
+        num_attended_heads=num_attended_heads)
 
 class Transformer(_DefaultTransformer):
   """Defines a Transformer model as decribed in https://arxiv.org/abs/1706.03762."""

--- a/opennmt/models/catalog.py
+++ b/opennmt/models/catalog.py
@@ -220,7 +220,7 @@ class LstmCnnCrfTagger(sequence_tagger.SequenceTagger):
     })
 
 class _DefaultTransformer(transformer.Transformer):
-  def __init__(self, big=False, relative=False):
+  def __init__(self, big=False, relative=False, conv=False):
     if big:
       num_units = 1024
       num_heads = 16
@@ -235,6 +235,8 @@ class _DefaultTransformer(transformer.Transformer):
     else:
       position_encoder_class = layers.SinusoidalPositionEncoder
       maximum_relative_position = None
+    attention_span = 5 if conv else None
+
     super(_DefaultTransformer, self).__init__(
         source_inputter=inputters.WordEmbedder(embedding_size=num_units),
         target_inputter=inputters.WordEmbedder(embedding_size=num_units),
@@ -246,7 +248,8 @@ class _DefaultTransformer(transformer.Transformer):
         attention_dropout=0.1,
         ffn_dropout=0.1,
         position_encoder_class=position_encoder_class,
-        maximum_relative_position=maximum_relative_position)
+        maximum_relative_position=maximum_relative_position,
+        attention_span=attention_span)
 
 class Transformer(_DefaultTransformer):
   """Defines a Transformer model as decribed in https://arxiv.org/abs/1706.03762."""
@@ -257,6 +260,11 @@ class TransformerRelative(_DefaultTransformer):
   """
   def __init__(self):
     super(TransformerRelative, self).__init__(relative=True)
+
+class TransformerConv(_DefaultTransformer):
+  """Defines a large Transformer model as decribed in https://arxiv.org/abs/1706.03762."""
+  def __init__(self):
+    super(TransformerBig, self).__init__(conv=True)
 
 class TransformerBig(_DefaultTransformer):
   """Defines a large Transformer model as decribed in https://arxiv.org/abs/1706.03762."""
@@ -269,6 +277,13 @@ class TransformerBigRelative(_DefaultTransformer):
   """
   def __init__(self):
     super(TransformerBigRelative, self).__init__(big=True, relative=True)
+
+class TransformerBigConv(_DefaultTransformer):
+  """Defines a large Transformer model using relative position representations as
+  described in https://arxiv.org/abs/1803.02155.
+  """
+  def __init__(self):
+    super(TransformerBigRelative, self).__init__(big=True, conv=True)
 
 class GPT2Small(language_model.LanguageModel):
   """GPT-2 language model (small version) as described in:

--- a/opennmt/models/catalog.py
+++ b/opennmt/models/catalog.py
@@ -264,7 +264,7 @@ class TransformerRelative(_DefaultTransformer):
 class TransformerConv(_DefaultTransformer):
   """Defines a large Transformer model as decribed in https://arxiv.org/abs/1706.03762."""
   def __init__(self):
-    super(TransformerBig, self).__init__(conv=True)
+    super(TransformerConv, self).__init__(conv=True)
 
 class TransformerBig(_DefaultTransformer):
   """Defines a large Transformer model as decribed in https://arxiv.org/abs/1706.03762."""
@@ -283,7 +283,7 @@ class TransformerBigConv(_DefaultTransformer):
   described in https://arxiv.org/abs/1803.02155.
   """
   def __init__(self):
-    super(TransformerBigRelative, self).__init__(big=True, conv=True)
+    super(TransformerBigConv, self).__init__(big=True, conv=True)
 
 class GPT2Small(language_model.LanguageModel):
   """GPT-2 language model (small version) as described in:

--- a/opennmt/models/transformer.py
+++ b/opennmt/models/transformer.py
@@ -30,7 +30,8 @@ class Transformer(SequenceToSequence):
                share_embeddings=EmbeddingsSharingLevel.NONE,
                share_encoders=False,
                maximum_relative_position=None,
-               attention_span=None):
+               attention_span=None,
+               num_attended_heads=1):
     """Initializes a Transformer model.
 
     Args:
@@ -61,6 +62,10 @@ class Transformer(SequenceToSequence):
         (from https://arxiv.org/abs/1803.02155).
       attention_span: Maximum relative position to attend to
         (from https://arxiv.org/abs/1904.03107).
+      num_attended_heads: How many heads should be attended. Defaults to 1
+        as each head only attends to itself in vanilla Transformer. Increase to
+        an odd number < `num_heads` to also model head interaction.
+        (from ttps://arxiv.org/abs/1904.03107).
     """
     encoders = [
         SelfAttentionEncoder(
@@ -74,7 +79,8 @@ class Transformer(SequenceToSequence):
             ffn_activation=ffn_activation,
             position_encoder_class=position_encoder_class,
             maximum_relative_position=maximum_relative_position,
-            attention_span=attention_span)
+            attention_span=attention_span,
+            num_attended_heads=num_attended_heads)
         for _ in range(source_inputter.num_outputs)]
     if len(encoders) > 1:
       encoder = ParallelEncoder(

--- a/opennmt/models/transformer.py
+++ b/opennmt/models/transformer.py
@@ -29,7 +29,8 @@ class Transformer(SequenceToSequence):
                position_encoder_class=SinusoidalPositionEncoder,
                share_embeddings=EmbeddingsSharingLevel.NONE,
                share_encoders=False,
-               maximum_relative_position=None):
+               maximum_relative_position=None,
+               attention_span=None):
     """Initializes a Transformer model.
 
     Args:
@@ -58,6 +59,8 @@ class Transformer(SequenceToSequence):
         separate encoders parameters or not.
       maximum_relative_position: Maximum relative position representation
         (from https://arxiv.org/abs/1803.02155).
+      attention_span: Maximum relative position to attend to
+        (from https://arxiv.org/abs/1904.03107).
     """
     encoders = [
         SelfAttentionEncoder(
@@ -70,7 +73,8 @@ class Transformer(SequenceToSequence):
             ffn_dropout=ffn_dropout,
             ffn_activation=ffn_activation,
             position_encoder_class=position_encoder_class,
-            maximum_relative_position=maximum_relative_position)
+            maximum_relative_position=maximum_relative_position,
+            attention_span=attention_span)
         for _ in range(source_inputter.num_outputs)]
     if len(encoders) > 1:
       encoder = ParallelEncoder(

--- a/opennmt/tests/transformer_test.py
+++ b/opennmt/tests/transformer_test.py
@@ -142,6 +142,13 @@ class TransformerTest(tf.test.TestCase):
     cache = (tf.zeros([4, 4, 0, 5]), tf.zeros([4, 4, 0, 5]))
     _, cache = attention(x, cache=cache)
 
+  def testMultiHeadSelfAttentionSpan(self):
+    attention = transformer.MultiHeadAttention(4, 20, span=1)
+    queries = tf.random.uniform([4, 5, 10])
+    mask = tf.sequence_mask([4, 3, 5, 2])
+    context, _ = attention(queries, mask=mask)
+    self.assertListEqual(context.shape.as_list(), [4, 5, 20])
+
   def testMultiHeadAttention(self):
     attention = transformer.MultiHeadAttention(4, 20)
     queries = tf.random.uniform([4, 5, 10])

--- a/opennmt/tests/transformer_test.py
+++ b/opennmt/tests/transformer_test.py
@@ -143,7 +143,7 @@ class TransformerTest(tf.test.TestCase):
     _, cache = attention(x, cache=cache)
 
   def testMultiHeadSelfAttentionSpan(self):
-    attention = transformer.MultiHeadAttention(4, 20, span=1)
+    attention = transformer.MultiHeadAttention(4, 20, span=1, num_attended_heads=3)
     queries = tf.random.uniform([4, 5, 10])
     mask = tf.sequence_mask([4, 3, 5, 2])
     context, _ = attention(queries, mask=mask)

--- a/opennmt/tests/transformer_test.py
+++ b/opennmt/tests/transformer_test.py
@@ -143,7 +143,7 @@ class TransformerTest(tf.test.TestCase):
     _, cache = attention(x, cache=cache)
 
   def testMultiHeadSelfAttentionSpan(self):
-    attention = transformer.MultiHeadAttention(4, 20, span=1, num_attended_heads=3)
+    attention = transformer.MultiHeadAttention(4, 20, attention_span=1, num_attended_heads=3)
     queries = tf.random.uniform([4, 5, 10])
     mask = tf.sequence_mask([4, 3, 5, 2])
     context, _ = attention(queries, mask=mask)


### PR DESCRIPTION
Inspired from the [Relative Position](https://arxiv.org/abs/1803.02155) implementation in the recent release I did some research on the attention mechanism at large and found [Convolutional Self-Attention Networks](https://arxiv.org/abs/1904.03107) interesting. While relevant advances are being published too fast to follow, the basic idea of constraining self-attention to fixed or learned windows is likely to become a central topic of research and therefore I tried implementing it. I would like to hear the community's opinions:

1. Does this make sense at all?
2. I am currently working on the 1-D implementation which already beats vanilla and relative Transformer (according to the paper), but the 2-D case seems to bring even more improvement. Should we also implement that? The extension shouldn't be too hard.

3. I added default model names in the `catalog` but I am not sure thats necessary. If we are happy with it we might be able to come up with a better name than `TransformerConv`


# Updates
Also implemented 2D convolution which essentially allows the query of each head to attend to (optionally time-step neighbourhood constrained) keys and values of nearby heads. I am now testing by training and will update with results. The paper is not super-clear on whether the winning implementation included head interaction in all encoder layers or merely the first 3 similar to one convolution. My interpretation was that indeed both operations only impacted the 3 first layers so that's what the `catalog` specification does, but I am not a native speaker of English so I may have misunderstood. 

## Some thoughts on 2D convolution.
While the idea of allowing interactions between heads is promising, formalising it as convolution can be misleading. Convolution is reasonable as a neighbourhood constraint mechanism in the time dimension because we have a reasonable inductive bias: words around the current one are more important to its context than words far away from it. However this does not hold true for the `heads` dimension: `HEAD 1` is in no way *closer* to `HEAD 2` than it is to `HEAD 5`. I still implemented it as a cyclic convolution but it feels like an implementation detail, I would expect it to work exactly the same if we attended to any other set of heads.