### PR TITLE
fix input-from-sgm.perl fetch

### DIFF
--- a/scripts/wmt/prepare_data.sh
+++ b/scripts/wmt/prepare_data.sh
@@ -81,7 +81,8 @@ testset=newstest2017-ende
 
 export PATH=$SP_PATH:$PATH
 
-wget -nc https://raw.githubusercontent.com/OpenNMT/OpenNMT-tf/master/third_party/input-from-sgm.perl
+# retrieve file preparation from Moses repository
+wget -nc https://raw.githubusercontent.com/moses-smt/mosesdecoder/master/scripts/ems/support/input-from-sgm.perl
 
 ##################################################################################
 # Starting from here, original files are supposed to be in $DATA_PATH


### PR DESCRIPTION
`third_party` directory not included anymore (since `r2`?)