### PR TITLE
refactor process_fn to be more generic through transform_fns

### DIFF
--- a/opennmt/data/dataset.py
+++ b/opennmt/data/dataset.py
@@ -439,6 +439,7 @@ def training_pipeline(batch_size,
                       batch_multiplier=1,
                       batch_size_multiple=1,
                       process_fn=None,
+                      transform_fns=[],
                       length_bucket_width=None,
                       features_length_fn=None,
                       labels_length_fn=None,
@@ -474,6 +475,8 @@ def training_pipeline(batch_size,
     batch_size_multiple: When :obj:`batch_type` is "tokens", ensure that the
       resulting batch size is a multiple of this value.
     process_fn: The processing function to apply on each element.
+    transform_fns: list of transformation functions (map or filter) to apply on
+      the batch. More generic than `process_fn`. 
     length_bucket_width: The width of the length buckets to select batch
       candidates from. ``None`` to not constrain batch formation.
     features_length_fn: A function mapping features to a sequence length.
@@ -542,11 +545,14 @@ def training_pipeline(batch_size,
       dataset = _make_single_dataset(dataset)
     if process_fn is not None:
       dataset = dataset.map(process_fn, num_parallel_calls=num_threads or 4)
-    dataset = dataset.apply(filter_examples_by_length(
-        maximum_features_length=maximum_features_length,
-        maximum_labels_length=maximum_labels_length,
-        features_length_fn=features_length_fn,
-        labels_length_fn=labels_length_fn))
+    for transform_fn in transform_fns:
+      dataset = dataset.apply(transform_fn)
+    if features_length_fn or labels_length_fn: # should be now be called as a transform_fn
+      dataset = dataset.apply(filter_examples_by_length(
+          maximum_features_length=maximum_features_length,
+          maximum_labels_length=maximum_labels_length,
+          features_length_fn=features_length_fn,
+          labels_length_fn=labels_length_fn))
     dataset = dataset.apply(batch_sequence_dataset(
         batch_size,
         batch_type=batch_type,
@@ -567,6 +573,7 @@ def training_pipeline(batch_size,
 
 def inference_pipeline(batch_size,
                        process_fn=None,
+                       transform_fns=None,
                        length_bucket_width=None,
                        length_fn=None,
                        num_threads=None,
@@ -580,6 +587,8 @@ def inference_pipeline(batch_size,
   Args:
     batch_size: The batch size to use.
     process_fn: The processing function to apply on each element.
+    transform_fns: list of transformation functions (only map for inference)
+      to apply on the batch. More generic than `process_fn`. 
     length_bucket_width: The width of the length buckets to select batch
       candidates from. If set, this means the inference pipeline will be
       reordered based on the examples length, the application is then
@@ -606,6 +615,8 @@ def inference_pipeline(batch_size,
   def _pipeline(dataset):
     if process_fn is not None:
       dataset = dataset.map(process_fn, num_parallel_calls=num_threads)
+    for transform_fn in transform_fns:
+      dataset = dataset.apply(transform_fn)
     if length_bucket_width is not None and length_bucket_width > 0:
       if length_fn is None:
         raise ValueError("length_fn is required when reordering by length")

--- a/opennmt/data/dataset.py
+++ b/opennmt/data/dataset.py
@@ -547,12 +547,12 @@ def training_pipeline(batch_size,
       dataset = dataset.map(process_fn, num_parallel_calls=num_threads or 4)
     for transform_fn in transform_fns:
       dataset = dataset.apply(transform_fn)
-    if features_length_fn or labels_length_fn: # should be now be called as a transform_fn
-      dataset = dataset.apply(filter_examples_by_length(
-          maximum_features_length=maximum_features_length,
-          maximum_labels_length=maximum_labels_length,
-          features_length_fn=features_length_fn,
-          labels_length_fn=labels_length_fn))
+    # the following is now by default part of transform_fn
+    dataset = dataset.apply(filter_examples_by_length(
+        maximum_features_length=maximum_features_length,
+        maximum_labels_length=maximum_labels_length,
+        features_length_fn=features_length_fn,
+        labels_length_fn=labels_length_fn))
     dataset = dataset.apply(batch_sequence_dataset(
         batch_size,
         batch_type=batch_type,

--- a/opennmt/data/dataset.py
+++ b/opennmt/data/dataset.py
@@ -439,7 +439,7 @@ def training_pipeline(batch_size,
                       batch_multiplier=1,
                       batch_size_multiple=1,
                       process_fn=None,
-                      transform_fns=[],
+                      transform_fns=None,
                       length_bucket_width=None,
                       features_length_fn=None,
                       labels_length_fn=None,
@@ -476,7 +476,7 @@ def training_pipeline(batch_size,
       resulting batch size is a multiple of this value.
     process_fn: The processing function to apply on each element.
     transform_fns: list of transformation functions (map or filter) to apply on
-      the batch. More generic than `process_fn`. 
+      the dataset. More generic than `process_fn`.
     length_bucket_width: The width of the length buckets to select batch
       candidates from. ``None`` to not constrain batch formation.
     features_length_fn: A function mapping features to a sequence length.
@@ -545,7 +545,7 @@ def training_pipeline(batch_size,
       dataset = _make_single_dataset(dataset)
     if process_fn is not None:
       dataset = dataset.map(process_fn, num_parallel_calls=num_threads or 4)
-    for transform_fn in transform_fns:
+    for transform_fn in transform_fns or []:
       dataset = dataset.apply(transform_fn)
     # the following is now by default part of transform_fn
     dataset = dataset.apply(filter_examples_by_length(
@@ -588,7 +588,7 @@ def inference_pipeline(batch_size,
     batch_size: The batch size to use.
     process_fn: The processing function to apply on each element.
     transform_fns: list of transformation functions (only map for inference)
-      to apply on the batch. More generic than `process_fn`. 
+      to apply on the dataset. More generic than `process_fn`.
     length_bucket_width: The width of the length buckets to select batch
       candidates from. If set, this means the inference pipeline will be
       reordered based on the examples length, the application is then
@@ -615,7 +615,7 @@ def inference_pipeline(batch_size,
   def _pipeline(dataset):
     if process_fn is not None:
       dataset = dataset.map(process_fn, num_parallel_calls=num_threads)
-    for transform_fn in transform_fns:
+    for transform_fn in transform_fns or []:
       dataset = dataset.apply(transform_fn)
     if length_bucket_width is not None and length_bucket_width > 0:
       if length_fn is None:

--- a/opennmt/inputters/inputter.py
+++ b/opennmt/inputters/inputter.py
@@ -90,8 +90,8 @@ class Inputter(tf.keras.layers.Layer):
     """
     map_func = lambda *arg: self.make_features(element=misc.item_or_tuple(arg), training=False)
     transform_fns = [lambda dataset:
-                        dataset.map(map_func,
-                                    num_parallel_calls=num_threads or 4)]
+                     dataset.map(map_func,
+                                 num_parallel_calls=num_threads or 4)]
     dataset = self.make_dataset(features_file, training=False)
     dataset = dataset.apply(dataset_util.inference_pipeline(
         batch_size,
@@ -488,8 +488,8 @@ class ExampleInputter(ParallelInputter):
     """
     map_func = lambda *arg: self.make_features(element=arg, training=False)
     transform_fns = [lambda dataset:
-                        dataset.map(map_func,
-                                    num_parallel_calls=num_threads or 4)]
+                     dataset.map(map_func,
+                                 num_parallel_calls=num_threads or 4)]
     dataset = self.make_dataset([features_file, labels_file], training=False)
     dataset = dataset.apply(dataset_util.inference_pipeline(
         batch_size,
@@ -567,13 +567,13 @@ class ExampleInputter(ParallelInputter):
     transform_fns = []
     map_func = lambda *arg: self.make_features(element=arg, training=True)
     transform_fns.append(lambda dataset:
-                          dataset.map(map_func,
-                                      num_parallel_calls=num_threads or 4))
+                         dataset.map(map_func,
+                                     num_parallel_calls=num_threads or 4))
     transform_fns.append(dataset_util.filter_examples_by_length(
-                        maximum_features_length=maximum_features_length,
-                        maximum_labels_length=maximum_labels_length,
-                        features_length_fn=self.features_inputter.get_length,
-                        labels_length_fn=self.labels_inputter.get_length))
+        maximum_features_length=maximum_features_length,
+        maximum_labels_length=maximum_labels_length,
+        features_length_fn=self.features_inputter.get_length,
+        labels_length_fn=self.labels_inputter.get_length))
     dataset = dataset_util.training_pipeline(
         batch_size,
         batch_type=batch_type,

--- a/opennmt/models/language_model.py
+++ b/opennmt/models/language_model.py
@@ -216,6 +216,7 @@ class LanguageModelInputter(inputters.WordEmbedder):
                             shuffle_buffer_size=None,
                             length_bucket_width=None,
                             maximum_features_length=None,
+                            maximum_labels_length=None,
                             single_pass=False,
                             num_shards=1,
                             shard_index=0,
@@ -235,6 +236,7 @@ class LanguageModelInputter(inputters.WordEmbedder):
                                      num_parallel_calls=num_threads or 4))
     transform_fns.append(dataset_util.filter_examples_by_length(
         maximum_features_length=maximum_features_length,
+        maximum_labels_length=maximum_labels_length,
         features_length_fn=self.get_length))
     dataset = dataset_util.training_pipeline(
         batch_size,

--- a/opennmt/models/language_model.py
+++ b/opennmt/models/language_model.py
@@ -173,9 +173,13 @@ class LanguageModelInputter(inputters.WordEmbedder):
                              num_threads=1,
                              prefetch_buffer_size=None):
     dataset = self.make_dataset(features_file, training=False)
+    map_func = lambda x: self.make_features(element=x, training=False)[0]
+    transform_fns = [lambda dataset:
+                       dataset.map(map_func,
+                                   num_parallel_calls=num_threads or 4)]
     dataset = dataset.apply(dataset_util.inference_pipeline(
         batch_size,
-        process_fn=lambda x: self.make_features(element=x, training=False)[0],
+        transform_fns=transform_fns,
         length_bucket_width=length_bucket_width,
         length_fn=self.get_length,
         num_threads=num_threads,
@@ -191,9 +195,13 @@ class LanguageModelInputter(inputters.WordEmbedder):
     """See :meth:`opennmt.inputters.ExampleInputter.make_evaluation_dataset`."""
     _ = labels_file
     dataset = self.make_dataset(features_file, training=False)
+    map_func = lambda x: self.make_features(element=x, training=False)
+    transform_fns = [lambda dataset:
+                       dataset.map(map_func,
+                                   num_parallel_calls=num_threads or 4)]
     dataset = dataset.apply(dataset_util.inference_pipeline(
         batch_size,
-        process_fn=lambda x: self.make_features(element=x, training=False),
+        transform_fns=transform_fns,
         num_threads=num_threads,
         prefetch_buffer_size=prefetch_buffer_size))
     return dataset
@@ -221,16 +229,21 @@ class LanguageModelInputter(inputters.WordEmbedder):
     dataset = self.make_dataset(features_file, training=True)
     if weights is not None:
       dataset = (dataset, weights)
+    transform_fns = []
+    map_func = lambda x: self.make_features(element=x, training=True)
+    transform_fns.append(lambda dataset:
+                           dataset.map(map_func))
+    transform_fns.append(dataset_util.filter_examples_by_length(
+                         maximum_features_length=maximum_features_length,
+                         maximum_labels_length=maximum_labels_length,
+                         features_length_fn=self.get_length))
     dataset = dataset_util.training_pipeline(
         batch_size,
         batch_type=batch_type,
         batch_multiplier=batch_multiplier,
         batch_size_multiple=batch_size_multiple,
-        process_fn=lambda x: self.make_features(element=x, training=True),
+        transform_fns=transform_fns,
         length_bucket_width=length_bucket_width,
-        features_length_fn=self.get_length,
-        maximum_features_length=maximum_features_length,
-        maximum_labels_length=maximum_labels_length,
         single_pass=single_pass,
         num_shards=num_shards,
         shard_index=shard_index,

--- a/opennmt/models/language_model.py
+++ b/opennmt/models/language_model.py
@@ -216,7 +216,6 @@ class LanguageModelInputter(inputters.WordEmbedder):
                             shuffle_buffer_size=None,
                             length_bucket_width=None,
                             maximum_features_length=None,
-                            maximum_labels_length=None,
                             single_pass=False,
                             num_shards=1,
                             shard_index=0,

--- a/opennmt/models/language_model.py
+++ b/opennmt/models/language_model.py
@@ -232,7 +232,8 @@ class LanguageModelInputter(inputters.WordEmbedder):
     transform_fns = []
     map_func = lambda x: self.make_features(element=x, training=True)
     transform_fns.append(lambda dataset:
-                         dataset.map(map_func))
+                         dataset.map(map_func,
+                                     num_parallel_calls=num_threads or 4))
     transform_fns.append(dataset_util.filter_examples_by_length(
         maximum_features_length=maximum_features_length,
         features_length_fn=self.get_length))

--- a/opennmt/models/language_model.py
+++ b/opennmt/models/language_model.py
@@ -235,7 +235,6 @@ class LanguageModelInputter(inputters.WordEmbedder):
                          dataset.map(map_func))
     transform_fns.append(dataset_util.filter_examples_by_length(
         maximum_features_length=maximum_features_length,
-        maximum_labels_length=maximum_labels_length,
         features_length_fn=self.get_length))
     dataset = dataset_util.training_pipeline(
         batch_size,

--- a/opennmt/models/language_model.py
+++ b/opennmt/models/language_model.py
@@ -175,8 +175,8 @@ class LanguageModelInputter(inputters.WordEmbedder):
     dataset = self.make_dataset(features_file, training=False)
     map_func = lambda x: self.make_features(element=x, training=False)[0]
     transform_fns = [lambda dataset:
-                       dataset.map(map_func,
-                                   num_parallel_calls=num_threads or 4)]
+                     dataset.map(map_func,
+                                 num_parallel_calls=num_threads or 4)]
     dataset = dataset.apply(dataset_util.inference_pipeline(
         batch_size,
         transform_fns=transform_fns,
@@ -197,8 +197,8 @@ class LanguageModelInputter(inputters.WordEmbedder):
     dataset = self.make_dataset(features_file, training=False)
     map_func = lambda x: self.make_features(element=x, training=False)
     transform_fns = [lambda dataset:
-                       dataset.map(map_func,
-                                   num_parallel_calls=num_threads or 4)]
+                     dataset.map(map_func,
+                                 num_parallel_calls=num_threads or 4)]
     dataset = dataset.apply(dataset_util.inference_pipeline(
         batch_size,
         transform_fns=transform_fns,
@@ -232,11 +232,11 @@ class LanguageModelInputter(inputters.WordEmbedder):
     transform_fns = []
     map_func = lambda x: self.make_features(element=x, training=True)
     transform_fns.append(lambda dataset:
-                           dataset.map(map_func))
+                         dataset.map(map_func))
     transform_fns.append(dataset_util.filter_examples_by_length(
-                         maximum_features_length=maximum_features_length,
-                         maximum_labels_length=maximum_labels_length,
-                         features_length_fn=self.get_length))
+        maximum_features_length=maximum_features_length,
+        maximum_labels_length=maximum_labels_length,
+        features_length_fn=self.get_length))
     dataset = dataset_util.training_pipeline(
         batch_size,
         batch_type=batch_type,


### PR DESCRIPTION
slight refactoring of training/inference pipeline to accept more generically a list of transformation function. keep existing parameters for API backward compatibility. 
This PR is needed for #635.