### PR TITLE
Update sacrebleu to 1.4.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         "pyonmttok>=1.18.1,<2;platform_system=='Linux'",
         "pyyaml>=5.3,<5.4",
         "rouge>=1.0,<2",
-        "sacrebleu==1.4.4",
+        "sacrebleu>=1.4.9,<2",
         "tensorflow>=2.1,<2.2",
         "tensorflow-addons>=0.8.1,<0.9",
         "pyter3==0.3"


### PR DESCRIPTION
This version removed the `mecab-python3` dependency which was not available on Windows.

Related to #653.