### PR TITLE
Factorize eval and train datasets construction from inputters

### DIFF
--- a/opennmt/data/dataset.py
+++ b/opennmt/data/dataset.py
@@ -475,8 +475,8 @@ def training_pipeline(batch_size,
     batch_size_multiple: When :obj:`batch_type` is "tokens", ensure that the
       resulting batch size is a multiple of this value.
     process_fn: The processing function to apply on each element.
-    transform_fns: list of transformation functions (map or filter) to apply on
-      the dataset. More generic than `process_fn`.
+    transform_fns: List of dataset transformation functions (applied after
+      :obj:`process_fn` if defined).
     length_bucket_width: The width of the length buckets to select batch
       candidates from. ``None`` to not constrain batch formation.
     features_length_fn: A function mapping features to a sequence length.
@@ -545,9 +545,9 @@ def training_pipeline(batch_size,
       dataset = _make_single_dataset(dataset)
     if process_fn is not None:
       dataset = dataset.map(process_fn, num_parallel_calls=num_threads or 4)
-    for transform_fn in transform_fns or []:
-      dataset = dataset.apply(transform_fn)
-    # the following is now by default part of transform_fn
+    if transform_fns is not None:
+      for transform_fn in transform_fns:
+        dataset = dataset.apply(transform_fn)
     dataset = dataset.apply(filter_examples_by_length(
         maximum_features_length=maximum_features_length,
         maximum_labels_length=maximum_labels_length,
@@ -587,8 +587,8 @@ def inference_pipeline(batch_size,
   Args:
     batch_size: The batch size to use.
     process_fn: The processing function to apply on each element.
-    transform_fns: list of transformation functions (only map for inference)
-      to apply on the dataset. More generic than `process_fn`.
+    transform_fns: List of dataset transformation functions (applied after
+      :obj:`process_fn` if defined).
     length_bucket_width: The width of the length buckets to select batch
       candidates from. If set, this means the inference pipeline will be
       reordered based on the examples length, the application is then
@@ -615,8 +615,9 @@ def inference_pipeline(batch_size,
   def _pipeline(dataset):
     if process_fn is not None:
       dataset = dataset.map(process_fn, num_parallel_calls=num_threads)
-    for transform_fn in transform_fns or []:
-      dataset = dataset.apply(transform_fn)
+    if transform_fns is not None:
+      for transform_fn in transform_fns:
+        dataset = dataset.apply(transform_fn)
     if length_bucket_width is not None and length_bucket_width > 0:
       if length_fn is None:
         raise ValueError("length_fn is required when reordering by length")

--- a/opennmt/inputters/__init__.py
+++ b/opennmt/inputters/__init__.py
@@ -5,6 +5,7 @@ e.g., from a line of text to a sequence of embeddings.
 """
 
 from opennmt.inputters.inputter import ExampleInputter
+from opennmt.inputters.inputter import ExampleInputterAdapter
 from opennmt.inputters.inputter import Inputter
 from opennmt.inputters.inputter import MixedInputter
 from opennmt.inputters.inputter import MultiInputter


### PR DESCRIPTION
This removes the duplicated code between `ExampleInputter` and `LanguageModelInputter` that we frequently forgot to keep in sync. Now an adapter class can build evaluation and training datasets for both supervised and unsupervised examples.