### PR TITLE
Faster dataset size computation for text training files

### DIFF
--- a/opennmt/inputters/text_inputter.py
+++ b/opennmt/inputters/text_inputter.py
@@ -285,6 +285,11 @@ class TextInputter(Inputter):
   def make_dataset(self, data_file, training=None):
     return dataset_util.make_datasets(tf.data.TextLineDataset, data_file)
 
+  def get_dataset_size(self, data_file):
+    if isinstance(data_file, list):
+      return list(map(misc.count_lines, data_file))
+    return misc.count_lines(data_file)
+
   def make_features(self, element=None, features=None, training=None):
     """Tokenizes raw text."""
     if features is None:

--- a/opennmt/utils/misc.py
+++ b/opennmt/utils/misc.py
@@ -135,13 +135,15 @@ def item_or_tuple(x):
   else:
     return x
 
-def count_lines(filename):
+def count_lines(filename, buffer_size=65536):
   """Returns the number of lines of the file :obj:`filename`."""
   with tf.io.gfile.GFile(filename, mode="rb") as f:
-    i = 0
-    for i, _ in enumerate(f):
-      pass
-    return i + 1
+    num_lines = 0
+    while True:
+      data = f.read(buffer_size)
+      if not data:
+        return num_lines
+      num_lines += data.count(b"\n")
 
 def is_gzip_file(filename):
   """Returns ``True`` if :obj:`filename` is a GZIP file."""


### PR DESCRIPTION
The generic way to compute the dataset size is to iterate over it. This is relatively slow. This change adds a faster code path for text training files where counting the number of lines is trivial.