### PR TITLE
Add a registry of exporters

### DIFF
--- a/opennmt/bin/main.py
+++ b/opennmt/bin/main.py
@@ -126,7 +126,7 @@ def main():
       "--export_dir", required=True,
       help="The directory of the exported model.")
   parser_export.add_argument(
-      "--export_format", choices=["saved_model", "ctranslate2"], default="saved_model",
+      "--export_format", choices=exporters.list_exporters(), default="saved_model",
       help="Format of the exported model.")
 
   parser_score = subparsers.add_parser("score", help="Scoring.")

--- a/opennmt/utils/__init__.py
+++ b/opennmt/utils/__init__.py
@@ -15,6 +15,7 @@ from opennmt.utils.decoding import dynamic_decode
 from opennmt.utils.exporters import CTranslate2Exporter
 from opennmt.utils.exporters import Exporter
 from opennmt.utils.exporters import SavedModelExporter
+from opennmt.utils.exporters import register_exporter
 
 from opennmt.utils.losses import cross_entropy_loss
 from opennmt.utils.losses import cross_entropy_sequence_loss


### PR DESCRIPTION
Like tokenizers, scorers, etc., this allows registering custom exporters in user code.