### PR TITLE
Avoid deepcopying the model instance

### DIFF
--- a/opennmt/bin/main.py
+++ b/opennmt/bin/main.py
@@ -207,7 +207,8 @@ def main():
       config["model_dir"],
       model_file=args.model,
       model_name=args.model_type,
-      serialize_model=is_master)
+      serialize_model=is_master,
+      as_builder=True)
   runner = Runner(
       model,
       config,

--- a/opennmt/models/catalog.py
+++ b/opennmt/models/catalog.py
@@ -23,14 +23,16 @@ def list_model_names_from_catalog():
   """Lists the models name registered in the catalog."""
   return _CATALOG_MODELS_REGISTRY.class_names
 
-def get_model_from_catalog(name):
+def get_model_from_catalog(name, as_builder=False):
   """Gets a model from the catalog.
 
   Args:
     name: The model name in the catalog.
+    as_builder: If ``True``, return a callable building the model on call.
 
   Returns:
-    A :class:`opennmt.models.Model` instance.
+    A :class:`opennmt.models.Model` instance or a callable returning such
+    instance.
 
   Raises:
     ValueError: if the model :obj:`name` does not exist in the catalog.
@@ -38,6 +40,8 @@ def get_model_from_catalog(name):
   model_class = _CATALOG_MODELS_REGISTRY.get(name)
   if model_class is None:
     raise ValueError("The model '%s' does not exist in the model catalog" % name)
+  if as_builder:
+    return model_class
   return model_class()
 
 

--- a/opennmt/tests/config_test.py
+++ b/opennmt/tests/config_test.py
@@ -48,16 +48,21 @@ class ConfigTest(tf.test.TestCase):
     self.assertIsInstance(model, Model)
 
   @parameterized.expand([
-      ("Transformer",),
-      ("TransformerBase",),
+      ("Transformer", False),
+      ("TransformerBase", True),
   ])
-  def testLoadModel(self, model_name):
+  def testLoadModel(self, model_name, as_builder):
+
+    def _check_model(model):
+      if as_builder:
+        self.assertTrue(model, callable)
+        model = model()
+      self.assertIsInstance(model, Model)
+
     model_dir = self.get_temp_dir()
-    model = config.load_model(model_dir, model_name=model_name)
+    _check_model(config.load_model(model_dir, model_name=model_name, as_builder=as_builder))
     self.assertTrue(os.path.exists(os.path.join(model_dir, "model_description.py")))
-    self.assertIsInstance(model, Model)
-    model = config.load_model(model_dir)
-    self.assertIsInstance(model, Model)
+    _check_model(config.load_model(model_dir, as_builder=as_builder))
 
   def testLoadModelDescriptionCompat(self):
     model_dir = self.get_temp_dir()


### PR DESCRIPTION
Calling `deepcopy` on a RNN model broke in TensorFlow 2.2. In general, it seems this is something we should avoid. In this change, we pass a model function to the `Runner` class so that it can build new model instances on demand.

This is a partial workaround for the issue described in https://github.com/OpenNMT/OpenNMT-tf/issues/672 as it only fixes the error for users training with `onmt-main` but not for users of the `Runner` class.

Fixes #672.