### PR TITLE
Update serving examples based on the latest model export

### DIFF
--- a/examples/serving/python/ende_client.py
+++ b/examples/serving/python/ende_client.py
@@ -2,9 +2,6 @@ import argparse
 import os
 
 import tensorflow as tf
-import tensorflow_addons as tfa
-tfa.register_all()  # Register custom ops.
-
 import pyonmttok
 
 

--- a/examples/serving/tensorflow_serving/README.md
+++ b/examples/serving/tensorflow_serving/README.md
@@ -4,7 +4,7 @@ This example shows how to start a TensorFlow Serving GPU instance and sends tran
 
 ## Requirements
 
-* [nvidia-docker](https://github.com/NVIDIA/nvidia-docker)
+* Docker 19.03 or above
 
 ## Usage
 
@@ -26,9 +26,9 @@ mv averaged-ende-export500k-v2 ende/1
 **3\. Start a TensorFlow Serving GPU instance in the background:**
 
 ```bash
-nvidia-docker run -d --rm -p 9000:9000 -v $PWD:/models \
+docker run --gpus=all -d --rm -p 9000:9000 -v $PWD:/models \
   --name tensorflow_serving --entrypoint tensorflow_model_server \
-  opennmt/tensorflow-serving:2.0.0-gpu \
+  tensorflow/serving:2.3.0-gpu \
   --enable_batching=true --batching_parameters_file=/models/batching_parameters.txt \
   --port=9000 --model_base_path=/models/ende --model_name=ende
 ```
@@ -62,11 +62,3 @@ Depending on your production requirements, you might need to build a simple prox
 
 * manage multiple TensorFlow Serving instances (possibly running on multiple hosts) and keep persistent channels to them
 * apply tokenization and detokenization
-
-For example, take a look at the OpenNMT-tf integration in the project [nmt-wizard-docker](https://github.com/OpenNMT/nmt-wizard-docker/blob/master/frameworks/opennmt_tf/entrypoint.py) which wraps a TensorFlow serving instance with a custom processing layer and REST API. It is possible to use exported OpenNMT-tf with nmt-wizard-docker with the [following approach](https://github.com/OpenNMT/nmt-wizard-docker/issues/46#issuecomment-456795844).
-
-## Custom TensorFlow Serving image
-
-The Docker image [`opennmt/tensorflow-serving`](https://hub.docker.com/r/opennmt/tensorflow-serving) includes additional TensorFlow ops used by OpenNMT-tf. For example, beam search decoding uses the op [`Addons>GatherTree`](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/custom_ops/seq2seq/cc/ops/beam_search_ops.cc) which is not available in standard TensorFlow Serving.
-
-**Models exported with OpenNMT-tf 2.12 and above no longer use this custom op and do not require a custom TensorFlow Serving image.**


### PR DESCRIPTION
Exported models no longer include a custom TensorFlow op.