### PR TITLE
Cleanup asset prefix generation and usage

### DIFF
--- a/opennmt/models/language_model.py
+++ b/opennmt/models/language_model.py
@@ -140,8 +140,8 @@ class LanguageModelInputter(inputters.WordEmbedder, inputters.ExampleInputterAda
   input sequence.
   """
 
-  def initialize(self, data_config, asset_prefix=""):
-    super(LanguageModelInputter, self).initialize(data_config, asset_prefix=asset_prefix)
+  def initialize(self, data_config):
+    super(LanguageModelInputter, self).initialize(data_config)
     # Set default sequence controls for backward compatibility.
     if self.mark_start is None:
       self.mark_start = False

--- a/opennmt/models/sequence_to_sequence.py
+++ b/opennmt/models/sequence_to_sequence.py
@@ -425,8 +425,8 @@ class SequenceToSequenceInputter(inputters.ExampleInputter):
     labels_inputter.set_decoder_mode(mark_start=True, mark_end=True)
     self.alignment_file = None
 
-  def initialize(self, data_config, asset_prefix=""):
-    super(SequenceToSequenceInputter, self).initialize(data_config, asset_prefix=asset_prefix)
+  def initialize(self, data_config):
+    super(SequenceToSequenceInputter, self).initialize(data_config)
     self.alignment_file = data_config.get("train_alignments")
 
   def make_dataset(self, data_file, training=None):

--- a/opennmt/tests/inputter_test.py
+++ b/opennmt/tests/inputter_test.py
@@ -506,6 +506,9 @@ class InputterTest(tf.test.TestCase):
         "source_tokenization": {"mode": "conservative"}
     })
     self.assertIsInstance(source_inputter.tokenizer, tokenizers.OpenNMTTokenizer)
+    asset_dir = self.get_temp_dir()
+    example_inputter.export_assets(asset_dir)
+    self.assertIn("source_tokenizer_config.yml", set(os.listdir(asset_dir)))
 
   def testMixedInputter(self):
     vocab_file = self._makeTextFile("vocab.txt", ["the", "world", "hello", "toto"])

--- a/opennmt/tests/misc_test.py
+++ b/opennmt/tests/misc_test.py
@@ -140,6 +140,13 @@ class MiscTest(tf.test.TestCase):
     with self.assertRaises(TypeError):
       registry.register(misc.ClassRegistry)
 
+  def testRelativeConfig(self):
+    config = misc.RelativeConfig({"a_1": 1, "1": 2, "2": 3}, prefix="a_")
+    self.assertEqual(config["1"], 1)
+    self.assertEqual(config["2"], 3)
+    with self.assertRaisesRegex(KeyError, "a_3"):
+      _ = config["3"]
+
 
 if __name__ == "__main__":
   tf.test.main()

--- a/opennmt/utils/misc.py
+++ b/opennmt/utils/misc.py
@@ -450,3 +450,36 @@ class ClassRegistry(object):
     in the registry.
     """
     return self._registry.get(name)
+
+class RelativeConfig(collections.abc.Mapping):
+  """Helper class to lookup keys relative to a prefix."""
+
+  def __init__(self, config, prefix=None, config_name=None):
+    """Initializes the relative configuration.
+
+    Args:
+      config: The configuration.
+      prefix: The prefix. Keys will be looked up relative to this prefix.
+      config_name: The name of the configuration, mostly used to make error
+        messages more explicit.
+    """
+    self._config = config
+    self._prefix = prefix or ""
+    self._config_name = config_name
+
+  def __getitem__(self, relative_key):
+    absolute_key = "%s%s" % (self._prefix, relative_key)
+    value = self._config.get(absolute_key)
+    if value is not None:
+      return value
+    value = self._config.get(relative_key)
+    if value is not None:
+      return value
+    raise KeyError("Missing field '%s' in the %sconfiguration" % (
+        absolute_key, self._config_name + " " if self._config_name else ""))
+
+  def __len__(self):
+    return len(self._config)
+
+  def __iter__(self):
+    return iter(self._config)


### PR DESCRIPTION
`asset_prefix` is used to differentiate resources used by parallel inputters.

The goal of this change is to allow inputters to read the data configuration as if there was no prefix. Ideally they should not know
that they are used with other inputters.

Now the `asset_prefix` attribute is correctly set for all parallel inputters and the data configuration is wrapped to allow making
relative lookups (e.g. "vocabulary" will resolve to "source_vocabulary").