### PR TITLE
Improve resolution of variable name in the checkpoint

### DIFF
--- a/opennmt/utils/checkpoint.py
+++ b/opennmt/utils/checkpoint.py
@@ -239,7 +239,7 @@ def average_checkpoints_into_layer(checkpoints, layer, layer_prefix):
     variable.assign(tf.zeros_like(variable))
 
   # Get a map from variable names in the checkpoint to variables in the layer.
-  _, names_to_variables = misc.get_variables_name_mapping(layer, root_key=layer_prefix)
+  names_to_variables = misc.get_variables_name_mapping(layer, root_key=layer_prefix)
 
   num_checkpoints = len(checkpoints)
   tf.get_logger().info("Averaging %d checkpoints...", num_checkpoints)

--- a/opennmt/utils/exporters.py
+++ b/opennmt/utils/exporters.py
@@ -97,7 +97,7 @@ class CTranslate2Exporter(Exporter):
       raise ValueError("The model does not define an equivalent CTranslate2 model specification")
     if not model.built:
       model.create_variables()
-    _, variables = misc.get_variables_name_mapping(model, root_key="model")
+    variables = misc.get_variables_name_mapping(model, root_key="model")
     variables = {
         name.replace("/.ATTRIBUTES/VARIABLE_VALUE", ""):value.numpy()
         for name, value in variables.items()}


### PR DESCRIPTION
The implementation is now more robust when variables are wrapped by an additional class (e.g. MirroredVariable, AutoCastVariable, etc.).