### PR TITLE
Cleanup moving average for mirrored variables

### DIFF
--- a/opennmt/tests/training_test.py
+++ b/opennmt/tests/training_test.py
@@ -27,6 +27,7 @@ class TrainingTest(tf.test.TestCase):
     step = tf.Variable(0, trainable=False, dtype=tf.int64)
     variables = [tf.Variable(1.0), tf.Variable(2.0)]
     moving_average = training.MovingAverage(variables, step)
+    moving_average.update()
     variables[0].assign(3.0)
     variables[1].assign(4.0)
     moving_average.update()

--- a/opennmt/tests/training_test.py
+++ b/opennmt/tests/training_test.py
@@ -45,9 +45,15 @@ class TrainingTest(tf.test.TestCase):
       step = tf.Variable(0, trainable=False, dtype=tf.int64)
 
     moving_average = training.MovingAverage(variables, step)
+    with strategy.scope():
+      moving_average.update()
+
     variables[0].assign(3.0)
     variables[1].assign(4.0)
-    moving_average.update()
+
+    with strategy.scope():
+      moving_average.update()
+
     self.assertAllEqual(self.evaluate(variables), [3.0, 4.0])
     with moving_average.shadow_variables():
       self.assertAllClose(self.evaluate(variables), [2.8, 3.8])

--- a/opennmt/utils/misc.py
+++ b/opennmt/utils/misc.py
@@ -72,13 +72,6 @@ def get_variable_name(variable, root, model_key="model"):
       return name
   return None
 
-def get_primary_variable(variable):
-  """If :obj:`variable` is distributed, returns the primary component."""
-  # TODO: use a public API to get the primary variable.
-  if isinstance(variable, tf.distribute.DistributedValues):
-    return variable._primary  # pylint: disable=protected-access
-  return variable
-
 def print_as_bytes(text, stream=None):
   """Prints a string as bytes to non rely on :obj:`stream` default encoding.
 


### PR DESCRIPTION
There is no need to get the primary variable to make it work. The update should be run under the distributed strategy scope.