### PR TITLE
Add decay_step_duration parameter

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -157,6 +157,8 @@ params:
   decay_params:
     model_dim: 512
     warmup_steps: 4000
+  # (optional) The number of training steps that make 1 decay step (default: 1).
+  decay_step_duration: 1
   # (optional) After how many steps to start the decay (default: 0).
   start_decay_steps: 50000
 

--- a/opennmt/models/model.py
+++ b/opennmt/models/model.py
@@ -218,6 +218,7 @@ class Model(tf.keras.layers.Layer):
           learning_rate,
           params["decay_type"],
           schedule_params=schedule_params,
+          schedule_step_duration=params.get("decay_step_duration", 1),
           start_step=params.get("start_decay_steps", 0),
           minimum_learning_rate=params.get("minimum_learning_rate", 0))
     optimizer_params = params.get("optimizer_params")


### PR DESCRIPTION
This was removed in OpenNMT-tf V2 but it can be useful in some cases.