### PR TITLE
Add sentence weighting

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -74,6 +74,10 @@ data:
   # (optional) Pharaoh alignments of the training files.
   train_alignments: data/toy-ende/alignments-train.txt
 
+  # (optional) File containing the weight of each example (one weight per line).
+  # The loss value of each example is multiplied by its corresponding weight.
+  example_weights: data/toy-ende/weights-train.txt
+
   # (required for train_end_eval and eval run types).
   eval_features_file: data/toy-ende/src-val.txt
   eval_labels_file: data/toy-ende/tgt-val.txt

--- a/opennmt/models/sequence_classifier.py
+++ b/opennmt/models/sequence_classifier.py
@@ -62,6 +62,7 @@ class SequenceClassifier(Model):
     return cross_entropy_loss(
         outputs,
         labels["classes_id"],
+        weight=labels.get("weight"),
         label_smoothing=self.params.get("label_smoothing", 0.0),
         training=training)
 

--- a/opennmt/models/sequence_tagger.py
+++ b/opennmt/models/sequence_tagger.py
@@ -77,7 +77,8 @@ class SequenceTagger(Model):
       return cross_entropy_sequence_loss(
           outputs,
           labels["tags_id"],
-          labels["length"],
+          sequence_length=labels["length"],
+          sequence_weight=labels.get("weight"),
           label_smoothing=self.params.get("label_smoothing", 0.0),
           average_in_time=self.params.get("average_loss_in_time", False),
           training=training)


### PR DESCRIPTION
Accept an additional file with weights that are used to scale the loss of their corresponding sentence. See also https://github.com/OpenNMT/OpenNMT-py/pull/1438.

Since loading this additional file is similar to how we currently load the alignments for guided alignment, this PR adds a generic framework to load training data annotations.