### PR TITLE
Rename parameter external_evaluators to scorers

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,7 +12,7 @@ params:
 train:
   # Training specific configuration (checkpoint frequency, number of training step, etc.)
 eval:
-  # Evaluation specific configuration (evaluation frequency, external evaluators.)
+  # Evaluation specific configuration (evaluation frequency, scorers, etc.)
 infer:
   # Inference specific configuration (output scores, alignments, etc.)
 score:
@@ -291,10 +291,10 @@ eval:
 
   # (optional) Save evaluation predictions in model_dir/eval/.
   save_eval_predictions: false
-  # (optional) Evalutator or list of evaluators that are called on the saved evaluation
+  # (optional) Scorer or list of scorers that are called on the saved evaluation
   # predictions.
-  # Available evaluators: bleu, rouge
-  external_evaluators: bleu
+  # Available scorers: bleu, rouge, wer, ter, prf
+  scorers: bleu
 
   # (optional) The width of the length buckets to select batch candidates from.
   # If set, the eval data will be sorted by length to increase the translation

--- a/docs/serving.md
+++ b/docs/serving.md
@@ -56,7 +56,7 @@ onmt-main [...] export --export_dir ~/my-models/ende --export_format ctranslate2
 
 ```yaml
 eval:
-  external_evaluators: bleu
+  scorers: bleu
   export_on_best: bleu
   export_format: ctranslate2
 ```

--- a/docs/training.md
+++ b/docs/training.md
@@ -51,7 +51,7 @@ Automatic evaluation can also export an inference model when a metric reaches it
 
 ```yaml
 eval:
-  external_evaluators: bleu
+  scorers: bleu
   export_on_best: bleu
 ```
 
@@ -65,7 +65,7 @@ For example, the following configuration stops the training when the BLEU score 
 
 ```yaml
 eval:
-  external_evaluators: bleu
+  scorers: bleu
   early_stopping:
     metric: bleu
     min_improvement: 0.2

--- a/opennmt/evaluation.py
+++ b/opennmt/evaluation.py
@@ -53,7 +53,7 @@ class Evaluator(object):
           scorers: A list of scorers, callables taking the path to the reference and
             the hypothesis and return one or more scores.
           save_predictions: Save evaluation predictions to a file. This is ``True``
-            when :obj:`external_evaluator` is set.
+            when :obj:`scorers` is set.
           early_stopping: An ``EarlyStopping`` instance.
           model_dir: The active model directory.
           export_on_best: Export a model when this evaluation metric has the
@@ -174,7 +174,10 @@ class Evaluator(object):
                 "features_file and labels_file should be both set for evaluation"
             )
         eval_config = config["eval"]
-        scorers = eval_config.get("external_evaluators")
+        scorers = eval_config.get("scorers")
+        if scorers is None:
+            # Backward compatibility with previous field name.
+            scorers = eval_config.get("external_evaluators")
         if scorers is not None:
             scorers = scorers_lib.make_scorers(scorers)
         early_stopping_config = eval_config.get("early_stopping")


### PR DESCRIPTION
Still accept `external_evaluators` for backward compatibility.