### PR TITLE
Do not repeat "export" in export command line options

### DIFF
--- a/docs/serving.md
+++ b/docs/serving.md
@@ -20,7 +20,7 @@ toy-ende/export/
 Models can be manually exported using the `export` run type:
 
 ```bash
-onmt-main --config my_config.yml --auto_config export --export_dir ~/my-models/ende
+onmt-main --config my_config.yml --auto_config export --output_dir ~/my-models/ende
 ```
 
 Automatic evaluation during the training can also export models, see [Training](training.md) to learn more.
@@ -46,10 +46,10 @@ TensorFlow Serving only runs TensorFlow operations. Preprocessing functions such
 
 Selected models can be exported to the CTranslate2 format directly from OpenNMT-tf by selecting the `ctranslate2` export format.
 
-**When using the `export` command line**, the `--export_format` option should be set:
+**When using the `export` command line**, the `--format` option should be set:
 
 ```bash
-onmt-main [...] export --export_dir ~/my-models/ende --export_format ctranslate2
+onmt-main [...] export --output_dir ~/my-models/ende --format ctranslate2
 ```
 
 **When using the automatic model evaluation and export during the training**, the `export_format` option should be configured in the `eval` block of the YAML configuration:

--- a/opennmt/bin/main.py
+++ b/opennmt/bin/main.py
@@ -194,9 +194,13 @@ def main():
 
     parser_export = subparsers.add_parser("export", help="Model export.")
     parser_export.add_argument(
-        "--export_dir", required=True, help="The directory of the exported model."
+        "--output_dir",
+        "--export_dir",
+        required=True,
+        help="The directory of the exported model.",
     )
     parser_export.add_argument(
+        "--format",
         "--export_format",
         choices=exporters.list_exporters(),
         default="saved_model",
@@ -338,9 +342,9 @@ def main():
         )
     elif args.run_type == "export":
         runner.export(
-            args.export_dir,
+            args.output_dir,
             checkpoint_path=args.checkpoint_path,
-            exporter=exporters.make_exporter(args.export_format),
+            exporter=exporters.make_exporter(args.format),
         )
     elif args.run_type == "score":
         runner.score(


### PR DESCRIPTION
Still accept previous option names for backward compatibility.