### PR TITLE
Use safe API when loading YAML configuration

### DIFF
--- a/opennmt/config.py
+++ b/opennmt/config.py
@@ -148,7 +148,7 @@ def load_config(config_paths, config=None):
 
     for config_path in config_paths:
         with tf.io.gfile.GFile(config_path) as config_file:
-            subconfig = yaml.load(config_file.read(), Loader=yaml.UnsafeLoader)
+            subconfig = yaml.safe_load(config_file.read())
             # Add or update section in main configuration.
             merge_dict(config, subconfig)
 

--- a/opennmt/tests/tokenizer_test.py
+++ b/opennmt/tests/tokenizer_test.py
@@ -160,7 +160,7 @@ class TokenizerTest(tf.test.TestCase):
 
         # The tokenization configuration should not contain absolute paths to resources.
         with open(assets["source_tokenizer_config.yml"]) as config_file:
-            asset_config = yaml.load(config_file.read(), Loader=yaml.UnsafeLoader)
+            asset_config = yaml.safe_load(config_file.read())
         self.assertDictEqual(
             asset_config, {"mode": "conservative", "bpe_model_path": "model.bpe"}
         )

--- a/opennmt/tokenizers/tokenizer.py
+++ b/opennmt/tokenizers/tokenizer.py
@@ -297,7 +297,7 @@ def make_tokenizer(config=None):
         if isinstance(config, str):
             if tf.io.gfile.exists(config):
                 with tf.io.gfile.GFile(config) as config_file:
-                    config = yaml.load(config_file, Loader=yaml.UnsafeLoader)
+                    config = yaml.safe_load(config_file)
             else:
                 try:
                     config = json.loads(config)

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         "ctranslate2>=1.7,<2;platform_system=='Linux'",
         "ctranslate2>=1.17,<2;platform_system=='Darwin'",
         "pyonmttok>=1.23.0,<2;platform_system=='Linux' or platform_system=='Darwin'",
-        "pyyaml>=5.3,<5.4",
+        "pyyaml>=5.3,<5.5",
         "rouge>=1.0,<2",
         "sacrebleu>=1.5.0,<1.6",
         "tensorflow>=2.3,<2.5",


### PR DESCRIPTION
The unsafe loader is able to create arbitrary Python object, but this is not something we need.