### PR TITLE
Build model in infer_tflite method

### DIFF
--- a/opennmt/models/sequence_to_sequence.py
+++ b/opennmt/models/sequence_to_sequence.py
@@ -198,6 +198,8 @@ class SequenceToSequence(model.SequenceGenerator):
         Args:
           ids: A 1-dimensional tensor with the ids of the sentence you want to predict
         """
+        if not self.built:
+            self.build(None)
         ids = tf.expand_dims(ids, axis=0)
         source_inputs = self.features_inputter.tflite_call(ids)
         source_length = tf.convert_to_tensor([tf.math.count_nonzero(ids)])

--- a/opennmt/tests/tflite_test.py
+++ b/opennmt/tests/tflite_test.py
@@ -18,7 +18,6 @@ def _create_vocab(temp_dir):
 def _make_model(model_template, vocab):
     model = model_template()
     model.initialize(dict(source_vocabulary=vocab, target_vocabulary=vocab))
-    model.create_variables()
     return model
 
 
@@ -37,10 +36,7 @@ def _get_predictions(model, dataset, vocab_path):
 
     _, pred = model(elem)
     pred_ids = tf.squeeze(tokens_to_ids.lookup(pred["tokens"]))
-    tflite_concrete_fn = tf.function(
-        model.infer_tflite,
-        input_signature=[tf.TensorSpec([None], dtype=tf.dtypes.int32, name="ids")],
-    ).get_concrete_function()
+    tflite_concrete_fn = model.tflite_function().get_concrete_function()
     tflite_pred_ids = tflite_concrete_fn(elem_ids)
 
     # Modify tflite ids tensor to be the same size as normal model output


### PR DESCRIPTION
Since this method is not calling the model `__call__` entrypoint, it should call `build()` by itself.

See https://github.com/OpenNMT/OpenNMT-tf/pull/789#issuecomment-788556988