### PR TITLE
Use Keras mixed precision API instead of auto_mixed_precision

### DIFF
--- a/docs/training.md
+++ b/docs/training.md
@@ -104,7 +104,7 @@ Mixed precision can be enabled with the `--mixed_precision` flag:
 onmt-main --model_type Transformer --auto_config --config data.yml --mixed_precision train
 ```
 
-It uses TensorFlow's `auto_mixed_precision` optimization which converts selected nodes in the graph to `float16`. During training, dynamic loss scaling is used.
+This mode enables the Keras "mixed\_float16" policy where layers use float16 computations and float32 variables. During training, dynamic loss scaling is used to prevent underflow in intermediate gradients. See the TensorFlow [mixed precision guide](https://www.tensorflow.org/guide/mixed_precision) for more information.
 
 ### Maximizing the FP16 performance
 

--- a/opennmt/runner.py
+++ b/opennmt/runner.py
@@ -87,7 +87,7 @@ class Runner(object):
         self._auto_config = auto_config
         self._mixed_precision = mixed_precision
         if mixed_precision:
-            tf.config.optimizer.set_experimental_options({"auto_mixed_precision": True})
+            misc.enable_mixed_precision()
         if seed is not None:
             np.random.seed(seed)
             random.seed(seed)

--- a/opennmt/runner.py
+++ b/opennmt/runner.py
@@ -85,9 +85,9 @@ class Runner(object):
         self._optimizer = None
         self._config = copy.deepcopy(config)
         self._auto_config = auto_config
-        self._mixed_precision = mixed_precision
-        if mixed_precision:
-            misc.enable_mixed_precision()
+        self._mixed_precision = (
+            misc.enable_mixed_precision() if mixed_precision else False
+        )
         if seed is not None:
             np.random.seed(seed)
             random.seed(seed)

--- a/opennmt/tests/runner_test.py
+++ b/opennmt/tests/runner_test.py
@@ -3,6 +3,7 @@ import os
 import unittest
 import shutil
 
+from distutils.version import LooseVersion
 from parameterized import parameterized, parameterized_class
 
 import tensorflow as tf
@@ -151,6 +152,9 @@ class RunnerTest(tf.test.TestCase):
 
     @test_util.run_with_mixed_precision
     def testTrainMixedPrecision(self):
+        if tf.config.functions_run_eagerly() and LooseVersion(tf.__version__) < "2.4.0":
+            # TODO: remove this skipTest once TensorFlow requirement is updated to >=2.4.
+            self.skipTest("Mixed precision not working with TensorFlow 2.3 + eager execution")
         self.assertTrue(misc.mixed_precision_enabled())
         ar_file, en_file = self._makeTransliterationData()
         config = {

--- a/opennmt/tests/runner_test.py
+++ b/opennmt/tests/runner_test.py
@@ -154,7 +154,9 @@ class RunnerTest(tf.test.TestCase):
     def testTrainMixedPrecision(self):
         if tf.config.functions_run_eagerly() and LooseVersion(tf.__version__) < "2.4.0":
             # TODO: remove this skipTest once TensorFlow requirement is updated to >=2.4.
-            self.skipTest("Mixed precision not working with TensorFlow 2.3 + eager execution")
+            self.skipTest(
+                "Mixed precision not working with TensorFlow 2.3 + eager execution"
+            )
         self.assertTrue(misc.mixed_precision_enabled())
         ar_file, en_file = self._makeTransliterationData()
         config = {

--- a/opennmt/tests/runner_test.py
+++ b/opennmt/tests/runner_test.py
@@ -149,6 +149,22 @@ class RunnerTest(tf.test.TestCase):
         runner = self._getTransliterationRunner(config)
         runner.train(num_devices=2)
 
+    @test_util.run_with_mixed_precision
+    def testTrainMixedPrecision(self):
+        self.assertTrue(misc.mixed_precision_enabled())
+        ar_file, en_file = self._makeTransliterationData()
+        config = {
+            "data": {"train_features_file": ar_file, "train_labels_file": en_file},
+            "params": {"learning_rate": 0.0005, "optimizer": "Adam"},
+            "train": {
+                "batch_size": 2,
+                "length_bucket_width": None,
+                "max_step": 145003,
+            },
+        }
+        runner = self._getTransliterationRunner(config)
+        runner.train()
+
     def testTrainWithEval(self):
         ar_file, en_file = self._makeTransliterationData()
         config = {

--- a/opennmt/tests/test_util.py
+++ b/opennmt/tests/test_util.py
@@ -8,6 +8,7 @@ from tensorflow.python.framework import ops
 from opennmt import constants
 from opennmt.data import vocab
 from opennmt.utils import compat
+from opennmt.utils import misc
 
 
 def skip_if_unsupported(symbol):
@@ -73,5 +74,18 @@ def run_with_two_cpu_devices(fn):
             return fn(*args, **kwargs)
         finally:
             _reset_context()
+
+    return decorator
+
+
+def run_with_mixed_precision(fn):
+    """Enables mixed precision before running :obj:`fn`."""
+
+    def decorator(*args, **kwargs):
+        misc.enable_mixed_precision()
+        try:
+            return fn(*args, **kwargs)
+        finally:
+            misc.disable_mixed_precision()
 
     return decorator

--- a/opennmt/tests/test_util.py
+++ b/opennmt/tests/test_util.py
@@ -82,7 +82,7 @@ def run_with_mixed_precision(fn):
     """Enables mixed precision before running :obj:`fn`."""
 
     def decorator(*args, **kwargs):
-        misc.enable_mixed_precision()
+        misc.enable_mixed_precision(force=True)
         try:
             return fn(*args, **kwargs)
         finally:

--- a/opennmt/utils/misc.py
+++ b/opennmt/utils/misc.py
@@ -71,23 +71,26 @@ def enable_mixed_precision(force=False):
     Returns:
       A boolean to indicate whether mixed precision was enabled or not.
     """
-    gpu_devices = tf.config.get_visible_devices("GPU")
-    if not gpu_devices:
-        tf.get_logger().warning("Mixed precision not enabled: no GPU is detected")
-        return False
+    if not force:
+        gpu_devices = tf.config.get_visible_devices("GPU")
+        if not gpu_devices:
+            tf.get_logger().warning("Mixed precision not enabled: no GPU is detected")
+            return False
 
-    gpu_details = tf.config.experimental.get_device_details(gpu_devices[0])
-    compute_capability = gpu_details.get("compute_capability")
-    if compute_capability is None:
-        tf.get_logger().warning("Mixed precision not enabled: a NVIDIA GPU is required")
-        return False
-    if compute_capability < (7, 0):
-        tf.get_logger().warning(
-            "Mixed precision not enabled: a NVIDIA GPU with compute "
-            "capability 7.0 or above is required, but the detected GPU "
-            "has compute capability %d.%d" % compute_capability
-        )
-        return False
+        gpu_details = tf.config.experimental.get_device_details(gpu_devices[0])
+        compute_capability = gpu_details.get("compute_capability")
+        if compute_capability is None:
+            tf.get_logger().warning(
+                "Mixed precision not enabled: a NVIDIA GPU is required"
+            )
+            return False
+        if compute_capability < (7, 0):
+            tf.get_logger().warning(
+                "Mixed precision not enabled: a NVIDIA GPU with compute "
+                "capability 7.0 or above is required, but the detected GPU "
+                "has compute capability %d.%d" % compute_capability
+            )
+            return False
 
     _set_global_policy("mixed_float16")
     return True

--- a/opennmt/utils/misc.py
+++ b/opennmt/utils/misc.py
@@ -97,7 +97,7 @@ def enable_mixed_precision(force=False):
 
 
 def disable_mixed_precision():
-    """Gloabally disables mixed precision."""
+    """Globally disables mixed precision."""
     _set_global_policy("float32")
 
 

--- a/opennmt/utils/misc.py
+++ b/opennmt/utils/misc.py
@@ -14,6 +14,8 @@ import tensorflow_addons as tfa
 
 from tensorflow.python.training.tracking import graph_view
 
+from opennmt.utils import compat
+
 
 def get_devices(count=1, fallback_to_cpu=True):
     """Gets devices.
@@ -46,6 +48,33 @@ def get_devices(count=1, fallback_to_cpu=True):
             )
         )
     return devices[0:count]
+
+
+# TODO: clean mixed precision API when TensorFlow requirement is updated to >=2.4.
+_set_global_policy = compat.tf_any(
+    "keras.mixed_precision.set_global_policy",
+    "keras.mixed_precision.experimental.set_policy",
+)
+_get_global_policy = compat.tf_any(
+    "keras.mixed_precision.global_policy",
+    "keras.mixed_precision.experimental.global_policy",
+)
+
+
+def enable_mixed_precision():
+    """Globally enables mixed precision."""
+    _set_global_policy("mixed_float16")
+
+
+def disable_mixed_precision():
+    """Gloabally disables mixed precision."""
+    _set_global_policy("float32")
+
+
+def mixed_precision_enabled():
+    """Returns ``True`` if mixed precision is enabled."""
+    policy = _get_global_policy()
+    return "float16" in policy.name
 
 
 def get_variables_name_mapping(root, root_key=None):


### PR DESCRIPTION
OpenNMT-tf used the "auto_mixed_precision" graph optimization pass to enable mixed precision training. However, the [Keras mixed precision API](https://www.tensorflow.org/guide/mixed_precision) appears to be the recommended API to enable mixed precision training in TensorFlow.