### PR TITLE
Remove direct dependency on TensorFlow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install -e .[tests]
+          python -m pip install -e .[tests,tensorflow-cpu]
 
       - name: Check code format with Black
         run: |
@@ -52,7 +52,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install tensorflow==${{ matrix.tensorflow }}.*
+          python -m pip install tensorflow-cpu==${{ matrix.tensorflow }}.*
           python -m pip install -e .[tests]
 
       - name: Download test data
@@ -115,7 +115,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install -e .
+          python -m pip install -e .[tensorflow-cpu]
           python -m pip install -r docs/requirements.txt
 
       - name: Build docs

--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ OpenNMT-tf also implements most of the techniques commonly used to train and eva
 
 OpenNMT-tf requires:
 
-* Python >= 3.5
+* Python 3.5 or above
+* TensorFlow 2.3, 2.4
 
 We recommend installing it with `pip`:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,8 @@
 
 OpenNMT-tf requires:
 
-* Python >= 3.5
+* Python 3.5 or above
+* TensorFlow 2.3, 2.4
 
 For GPU support, please read the [TensorFlow documentation](https://www.tensorflow.org/install/gpu) for additional software and hardware requirements.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -6,7 +6,7 @@ This page presents a minimal workflow to get you started in using OpenNMT-tf. Th
 
 ```bash
 pip install --upgrade pip
-pip install OpenNMT-tf
+pip install OpenNMT-tf[tensorflow]
 ```
 
 ## Step 1: Prepare the data

--- a/opennmt/__init__.py
+++ b/opennmt/__init__.py
@@ -1,5 +1,9 @@
 """OpenNMT module."""
 
+from opennmt.version import __version__, _check_tf_version
+
+_check_tf_version()
+
 from opennmt.config import convert_to_v2_config
 from opennmt.config import load_config
 from opennmt.config import load_model
@@ -13,5 +17,3 @@ from opennmt.constants import START_OF_SENTENCE_TOKEN
 from opennmt.constants import UNKNOWN_TOKEN
 
 from opennmt.runner import Runner
-
-from opennmt.version import __version__

--- a/opennmt/version.py
+++ b/opennmt/version.py
@@ -1,3 +1,27 @@
 """OpenNMT-tf version."""
 
 __version__ = "2.16.0"
+
+INCLUSIVE_MIN_TF_VERSION = "2.3.0"
+EXCLUSIVE_MAX_TF_VERSION = "2.5.0"
+
+
+def _check_tf_version():
+    from distutils.version import LooseVersion
+
+    import tensorflow as tf
+    import warnings
+
+    if (
+        LooseVersion(INCLUSIVE_MIN_TF_VERSION)
+        <= LooseVersion(tf.__version__)
+        < LooseVersion(EXCLUSIVE_MAX_TF_VERSION)
+    ):
+        return
+
+    warnings.warn(
+        "OpenNMT-tf supports TensorFlow versions %s (included) to %s (excluded), "
+        "but you have TensorFlow %s installed. Some features might not work properly."
+        % (INCLUSIVE_MIN_TF_VERSION, EXCLUSIVE_MAX_TF_VERSION, tf.__version__),
+        UserWarning,
+    )

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,6 @@ ignore =
   E731,
   F401,
   W503,
+per-file-ignores =
+  # Allow import not at top.
+  opennmt/__init__.py:E402

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ import os
 
 from setuptools import setup, find_packages
 
+base_dir = os.path.dirname(os.path.abspath(__file__))
 tests_require = [
     "black==20.8b1",
     "flake8==3.8.*",
@@ -11,14 +12,28 @@ tests_require = [
 
 
 def get_long_description():
-    readme_path = os.path.join(os.path.dirname(__file__), "README.md")
+    readme_path = os.path.join(base_dir, "README.md")
     with open(readme_path, encoding="utf-8") as readme_file:
         return readme_file.read()
 
 
+def get_project_version():
+    version = {}
+    with open(os.path.join(base_dir, "opennmt", "version.py"), encoding="utf-8") as fp:
+        exec(fp.read(), version)
+    return version
+
+
+version = get_project_version()
+tf_version_requirement = ">=%s,<%s" % (
+    version["INCLUSIVE_MIN_TF_VERSION"],
+    version["EXCLUSIVE_MAX_TF_VERSION"],
+)
+
+
 setup(
     name="OpenNMT-tf",
-    version="2.16.0",
+    version=version["__version__"],
     license="MIT",
     description="Neural machine translation and sequence learning using TensorFlow",
     long_description=get_long_description(),
@@ -53,10 +68,12 @@ setup(
         "pyyaml>=5.3,<5.5",
         "rouge>=1.0,<2",
         "sacrebleu>=1.5.0,<1.6",
-        "tensorflow>=2.3,<2.5",
         "tensorflow-addons>=0.12,<0.13",
     ],
     extras_require={
+        "tensorflow": ["tensorflow" + tf_version_requirement],
+        "tensorflow-cpu": ["tensorflow-cpu" + tf_version_requirement],
+        "tensorflow-gpu": ["tensorflow-gpu" + tf_version_requirement],
         "tests": tests_require,
     },
     tests_require=tests_require,

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,6 @@ setup(
     extras_require={
         "tensorflow": ["tensorflow" + tf_version_requirement],
         "tensorflow-cpu": ["tensorflow-cpu" + tf_version_requirement],
-        "tensorflow-gpu": ["tensorflow-gpu" + tf_version_requirement],
         "tests": tests_require,
     },
     tests_require=tests_require,

--- a/tools/update_version.py
+++ b/tools/update_version.py
@@ -5,7 +5,6 @@ import re
 
 SRC_DIR = "."
 VERSION_FILE = "%s/opennmt/version.py" % SRC_DIR
-SETUP_PY = "%s/setup.py" % SRC_DIR
 CHANGELOG = "%s/CHANGELOG.md" % SRC_DIR
 
 
@@ -37,9 +36,6 @@ def main():
         '__version__ = "%s"' % current_version,
         '__version__ = "%s"' % new_version,
         VERSION_FILE,
-    )
-    replace_string_in_file(
-        'version="%s"' % current_version, 'version="%s"' % new_version, SETUP_PY
     )
     replace_string_in_file(
         r"## \[Unreleased\]",


### PR DESCRIPTION
There are multiple official and community TensorFlow packages out there: tensorflow, tensorflow-cpu, tensorflow-gpu, tf-nightly, tensorflow-rocm, intel-tensorflow, tensorflow-macos, etc.

The main "tensorflow" package works in most cases but ultimately we should allow users to install an alternative package.

The TensorFlow version will be checked on import and a warning will be raised if the version is not officially supported.