### PR TITLE
Revert "Allow non fully defined gradient shape when accumulating gradients"

### DIFF
--- a/opennmt/optimizers/utils.py
+++ b/opennmt/optimizers/utils.py
@@ -136,9 +136,6 @@ class GradientAccumulator(object):
             return
         self._accum_steps.assign(0)
         for gradient in self._gradients:
-            shape = (
-                gradient.shape
-                if gradient.shape.is_fully_defined()
-                else tf.shape(gradient)
+            gradient.assign(
+                tf.zeros(gradient.shape, dtype=gradient.dtype), read_value=False
             )
-            gradient.assign(tf.zeros(shape, dtype=gradient.dtype), read_value=False)

--- a/opennmt/tests/transformer_test.py
+++ b/opennmt/tests/transformer_test.py
@@ -159,6 +159,20 @@ class TransformerTest(tf.test.TestCase):
         cache = (tf.zeros([4, 4, 0, 5]), tf.zeros([4, 4, 0, 5]))
         _, cache = attention(x, cache=cache)
 
+    def testMultiHeadSelfAttentionRelativeGradients(self):
+        attention = transformer.MultiHeadAttention(4, 20, maximum_relative_position=6)
+
+        @tf.function
+        def _compute_gradients_in_function(x):
+            with tf.GradientTape() as tape:
+                y, _ = attention(x)
+                loss = tf.math.reduce_sum(y)
+            gradients = tape.gradient(loss, attention.weights)
+            for gradient in gradients:
+                self.assertTrue(gradient.shape.is_fully_defined())
+
+        _compute_gradients_in_function(tf.random.uniform([4, 1, 10]))
+
     def testMultiHeadAttention(self):
         attention = transformer.MultiHeadAttention(4, 20, return_attention=True)
         queries = tf.random.uniform([4, 5, 10])


### PR DESCRIPTION
Reverts OpenNMT/OpenNMT-tf#825

This was a regression in TensorFlow 2.5 RC that will be fixed in the final release: https://github.com/tensorflow/tensorflow/issues/48430