### PR TITLE
Forward current environment variables when autotuning batch size

### DIFF
--- a/opennmt/runner.py
+++ b/opennmt/runner.py
@@ -559,9 +559,8 @@ def _auto_tune_batch_size(
             with tf.io.gfile.GFile(config_path, mode="w") as config_file:
                 yaml.dump(run_config, config_file)
 
-            env = {
-                "TF_CPP_MIN_LOG_LEVEL": "2",
-            }
+            env = os.environ.copy()
+            env["TF_CPP_MIN_LOG_LEVEL"] = "2"
             args = [
                 sys.executable or "python",
                 "-m",


### PR DESCRIPTION
When creating a subprocess, the default behavior is to forward the current environment variables to the child process. But in commit https://github.com/OpenNMT/OpenNMT-tf/commit/80ce857726296acd9280816c4a25f78f3ef41ce4, the `env` argument is explicitly set and so the other variables were no longer forwarded.

Possible fix for #847.