### PR TITLE
Add SentencePieceTokenizer from tensorflow-text

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install -e .[tests,tensorflow-cpu]
+          python -m pip install -e .[tests,tensorflow]
 
       - name: Check code format with Black
         run: |
@@ -52,7 +52,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install tensorflow-cpu==${{ matrix.tensorflow }}.*
+          python -m pip install tensorflow==${{ matrix.tensorflow }}.* tensorflow-text==${{ matrix.tensorflow }}.*
           python -m pip install -e .[tests]
 
       - name: Download test data
@@ -116,7 +116,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install -e .[tensorflow-cpu]
+          python -m pip install -e .[tensorflow]
           python -m pip install -r docs/requirements.txt
 
       - name: Build docs

--- a/opennmt/tests/tokenizer_test.py
+++ b/opennmt/tests/tokenizer_test.py
@@ -151,7 +151,7 @@ class TokenizerTest(tf.test.TestCase):
 
             @tf.function(input_signature=[tf.TensorSpec(shape=[None], dtype=tf.string)])
             def call(self, text):
-                return self._tokenizer.tokenize(text)
+                return self._tokenizer.tokenize(text).to_tensor()
 
         # Use a temporary model file to make sure the exported model is self-contained.
         tmp_model_path = os.path.join(self.get_temp_dir(), "sp.model")
@@ -164,9 +164,7 @@ class TokenizerTest(tf.test.TestCase):
         imported = tf.saved_model.load(export_dir)
         func = imported.signatures["serving_default"]
         outputs = func(tf.constant(text))["output_0"]
-        self.assertAllEqual(
-            outputs.to_list(), tf.nest.map_structure(tf.compat.as_bytes, tokens)
-        )
+        self.assertAllEqual(outputs, tf.nest.map_structure(tf.compat.as_bytes, tokens))
 
     def testOpenNMTTokenizer(self):
         self._testTokenizer(

--- a/opennmt/tokenizers/__init__.py
+++ b/opennmt/tokenizers/__init__.py
@@ -9,6 +9,11 @@ try:
 except ImportError:
     pass
 
+try:
+    from opennmt.tokenizers.sentencepiece_tokenizer import SentencePieceTokenizer
+except ImportError:
+    pass
+
 from opennmt.tokenizers.tokenizer import Tokenizer
 from opennmt.tokenizers.tokenizer import SpaceTokenizer
 from opennmt.tokenizers.tokenizer import CharacterTokenizer

--- a/opennmt/tokenizers/opennmt_tokenizer.py
+++ b/opennmt/tokenizers/opennmt_tokenizer.py
@@ -12,9 +12,15 @@ from opennmt.tokenizers import tokenizer
 
 @tokenizer.register_tokenizer
 class OpenNMTTokenizer(tokenizer.Tokenizer):
-    """Uses the OpenNMT tokenizer."""
+    """Tokenizer based on the OpenNMT Tokenizer: https://github.com/OpenNMT/Tokenizer."""
 
     def __init__(self, **kwargs):
+        """Initializes the tokenizer.
+
+        Args:
+          **kwargs: Tokenization options, see
+            https://github.com/OpenNMT/Tokenizer/blob/master/docs/options.md.
+        """
         case_feature = kwargs.get("case_feature")
         if case_feature:
             raise ValueError("case_feature is not supported with OpenNMT-tf")

--- a/opennmt/tokenizers/sentencepiece_tokenizer.py
+++ b/opennmt/tokenizers/sentencepiece_tokenizer.py
@@ -1,0 +1,42 @@
+"""SentencePiece tokenizer."""
+
+import tensorflow as tf
+import tensorflow_text as tft
+
+from opennmt.tokenizers import tokenizer
+
+
+@tokenizer.register_tokenizer
+class SentencePieceTokenizer(tokenizer.TensorFlowTokenizer):
+    """In-graph SentencePiece tokenizer using
+    ``tensorflow_text.SentencepieceTokenizer``.
+    """
+
+    def __init__(self, model, nbest_size=0, alpha=1.0):
+        """Initializes the tokenizer.
+
+        Args:
+          model: Path to the SentencePiece model.
+          nbest_size: Number of candidates to sample from (disabled during inference).
+          alpha: Smoothing parameter for the sampling.
+        """
+        super().__init__()
+        self._nbest_size = nbest_size
+        with tf.io.gfile.GFile(model, "rb") as model_file:
+            self._tokenizer = tft.SentencepieceTokenizer(
+                model=model_file.read(),
+                out_type=tf.string,
+                nbest_size=nbest_size,
+                alpha=alpha,
+            )
+
+    def _tokenize_tensor(self, text, training):
+        if not training:
+            self._tokenizer.nbest_size = 0
+        tokens = self._tokenizer.tokenize(text)
+        if not training:
+            self._tokenizer.nbest_size = self._nbest_size
+        return tokens
+
+    def _detokenize_tensor(self, tokens):
+        return self._tokenizer.detokenize(tokens)

--- a/opennmt/tokenizers/tokenizer.py
+++ b/opennmt/tokenizers/tokenizer.py
@@ -293,6 +293,86 @@ def make_tokenizer(config=None):
     return tokenizer
 
 
+def _process_stream_as_dataset(
+    input_stream,
+    output_stream,
+    map_func,
+    batch_size=512,
+    num_parallel_calls=4,
+):
+    input_spec = tf.TensorSpec(shape=(), dtype=tf.string)
+    output_spec = tf.TensorSpec(shape=(None,), dtype=tf.string)
+
+    dataset = tf.data.Dataset.from_generator(
+        lambda: input_stream,
+        output_signature=input_spec,
+    )
+    dataset = dataset.batch(batch_size)
+    dataset = dataset.map(map_func, num_parallel_calls=num_parallel_calls)
+    if dataset.element_spec != output_spec:
+        raise TypeError(
+            "Expected map_func to produce elements with spec %s, but got spec %s instead"
+            % (output_spec, dataset.element_spec)
+        )
+
+    for lines in dataset.as_numpy_iterator():
+        for line in lines:
+            misc.print_as_bytes(line, stream=output_stream)
+
+
+class TensorFlowTokenizer(tf.Module, Tokenizer):
+    """Base class for tokenizers using only TensorFlow ops."""
+
+    @property
+    def in_graph(self):
+        return True
+
+    def tokenize_stream(
+        self,
+        input_stream=sys.stdin,
+        output_stream=sys.stdout,
+        delimiter=" ",
+        training=True,
+    ):
+        def _map_func(line):
+            line = tf.strings.strip(line)
+            tokens = self._tokenize_tensor(line, training)
+            return tf.strings.reduce_join(
+                tokens, axis=tokens.shape.rank - 1, separator=delimiter
+            )
+
+        _process_stream_as_dataset(input_stream, output_stream, _map_func)
+
+    def detokenize_stream(
+        self,
+        input_stream=sys.stdin,
+        output_stream=sys.stdout,
+        delimiter=" ",
+    ):
+        def _map_func(line):
+            line = tf.strings.strip(line)
+            tokens = tf.strings.split(line, sep=delimiter)
+            return self._detokenize_tensor(tokens)
+
+        _process_stream_as_dataset(input_stream, output_stream, _map_func)
+
+    @abc.abstractmethod
+    def _tokenize_tensor(self, text, training):
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def _detokenize_tensor(self, tokens):
+        raise NotImplementedError()
+
+    def _tokenize_string(self, text, training):
+        tokens = self._tokenize_tensor(tf.constant(text, dtype=tf.string), training)
+        return [token.decode("utf-8") for token in tokens.numpy()]
+
+    def _detokenize_string(self, tokens):
+        text = self._detokenize_tensor(tf.constant(tokens, dtype=tf.string))
+        return text.numpy().decode("utf-8")
+
+
 @register_tokenizer
 class SpaceTokenizer(Tokenizer):
     """A tokenizer that splits on spaces."""

--- a/opennmt/tokenizers/tokenizer.py
+++ b/opennmt/tokenizers/tokenizer.py
@@ -300,19 +300,19 @@ def _process_stream_as_dataset(
     batch_size=512,
     num_parallel_calls=4,
 ):
-    input_spec = tf.TensorSpec(shape=(), dtype=tf.string)
-    output_spec = tf.TensorSpec(shape=(None,), dtype=tf.string)
-
     dataset = tf.data.Dataset.from_generator(
         lambda: input_stream,
-        output_signature=input_spec,
+        output_types=tf.string,
+        output_shapes=tf.TensorShape([]),
     )
     dataset = dataset.batch(batch_size)
     dataset = dataset.map(map_func, num_parallel_calls=num_parallel_calls)
-    if dataset.element_spec != output_spec:
+
+    expected_spec = tf.TensorSpec(shape=[None], dtype=tf.string)
+    if dataset.element_spec != expected_spec:
         raise TypeError(
             "Expected map_func to produce elements with spec %s, but got spec %s instead"
-            % (output_spec, dataset.element_spec)
+            % (expected_spec, dataset.element_spec)
         )
 
     for lines in dataset.as_numpy_iterator():

--- a/setup.py
+++ b/setup.py
@@ -72,8 +72,10 @@ setup(
         "tensorflow-addons>=0.13,<0.14",
     ],
     extras_require={
-        "tensorflow": ["tensorflow" + tf_version_requirement],
-        "tensorflow-cpu": ["tensorflow-cpu" + tf_version_requirement],
+        "tensorflow": [
+            "tensorflow" + tf_version_requirement,
+            "tensorflow-text" + tf_version_requirement,
+        ],
         "tests": tests_require,
     },
     tests_require=tests_require,


### PR DESCRIPTION
This tokenizer is implemented as a TensorFlow op so it can be included in the exported graph. It should also be more efficient than the OpenNMT tokenizer when used on-the-fly during the training.