### PR TITLE
Copy gather_tree functions from TF Addons to re-enable beam tests

### DIFF
--- a/opennmt/tests/runner_test.py
+++ b/opennmt/tests/runner_test.py
@@ -216,8 +216,6 @@ class RunnerTest(tf.test.TestCase):
         runner.train()
 
     def testEvaluate(self):
-        if not tf.config.functions_run_eagerly():
-            self.skipTest("Test case not passing in GitHub Actions environment")
         ar_file, en_file = self._makeTransliterationData()
         config = {
             "params": {"beam_width": 4},
@@ -232,8 +230,6 @@ class RunnerTest(tf.test.TestCase):
 
     @parameterized.expand([[1, "v2"], [4, "v2"], [1, "v1"]])
     def testInfer(self, beam_size, model_version):
-        if not tf.config.functions_run_eagerly() and beam_size != 1:
-            self.skipTest("Test case not passing in GitHub Actions environment")
         config = {"params": {"beam_width": beam_size}}
         runner = self._getTransliterationRunner(config, model_version)
         ar_file, _ = self._makeTransliterationData()

--- a/opennmt/utils/misc.py
+++ b/opennmt/utils/misc.py
@@ -10,7 +10,6 @@ import sys
 
 import numpy as np
 import tensorflow as tf
-import tensorflow_addons as tfa
 
 from tensorflow.python.training.tracking import graph_view
 
@@ -427,21 +426,6 @@ def read_summaries(event_dir, event_file_pattern="events.out.tfevents.*"):
                 )
                 summaries[event.step][value.tag] = tf.get_static_value(tensor)
     return list(sorted(summaries.items(), key=lambda x: x[0]))
-
-
-def disable_tfa_custom_ops(func):
-    """A decorator that disables TensorFlow Addons custom ops in a function."""
-
-    def _wrapper(*args, **kwargs):
-        if tfa.options.is_custom_kernel_disabled():
-            return func(*args, **kwargs)
-        tfa.options.disable_custom_kernel()
-        try:
-            return func(*args, **kwargs)
-        finally:
-            tfa.options.enable_custom_kernel()
-
-    return _wrapper
 
 
 class OrderRestorer(object):


### PR DESCRIPTION
The gather_tree function in TensorFlow Addons is wrapped by a `tf.function`. This should not be an issue, but it appears that the function gets unexpectedly garbage collected when running our test suite.