### PR TITLE
Remove environment markers for pyonmttok package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     python_requires=">=3.5",
     install_requires=[
         "ctranslate2>=2.0.0,<3;platform_system=='Linux' or platform_system=='Darwin'",
-        "pyonmttok>=1.26.4,<2;platform_system=='Linux' or platform_system=='Darwin'",
+        "pyonmttok>=1.26.4,<2",
         "pyyaml>=5.3,<5.5",
         "rouge>=1.0,<2",
         "sacrebleu>=1.5.0,<2.1",


### PR DESCRIPTION
The package is now available on Linux, macOS, and Windows.