### PR TITLE
Allow setting all learning rate schedules parameters

### DIFF
--- a/opennmt/models/model.py
+++ b/opennmt/models/model.py
@@ -330,12 +330,14 @@ class Model(tf.keras.layers.Layer):
         optimizer_name = params.get("optimizer")
         if optimizer_name is None:
             return None
-        learning_rate = tf.constant(params["learning_rate"], dtype=tf.float32)
-        if params.get("decay_type") is not None:
+        schedule_type = params.get("decay_type")
+        if schedule_type is None:
+            learning_rate = tf.constant(params["learning_rate"], dtype=tf.float32)
+        else:
             schedule_params = params.get("decay_params", {})
             learning_rate = schedules.make_learning_rate_schedule(
-                learning_rate,
-                params["decay_type"],
+                params.get("learning_rate"),
+                schedule_type,
                 schedule_params=schedule_params,
                 schedule_step_duration=params.get("decay_step_duration", 1),
                 start_step=params.get("start_decay_steps", 0),

--- a/opennmt/tests/lr_schedules_test.py
+++ b/opennmt/tests/lr_schedules_test.py
@@ -31,10 +31,18 @@ class LRSchedulesTest(tf.test.TestCase):
         self.assertIsInstance(
             wrapper.schedule, tf.keras.optimizers.schedules.ExponentialDecay
         )
+
         wrapper = lr_schedules.make_learning_rate_schedule(
             2.0, "NoamDecay", dict(model_dim=512, warmup_steps=4000)
         )
         self.assertIsInstance(wrapper.schedule, lr_schedules.NoamDecay)
+        self.assertEqual(wrapper.schedule.scale, 2)
+
+        wrapper = lr_schedules.make_learning_rate_schedule(
+            None, "NoamDecay", dict(scale=2, model_dim=512, warmup_steps=4000)
+        )
+        self.assertEqual(wrapper.schedule.scale, 2)
+
         with self.assertRaises(ValueError):
             lr_schedules.make_learning_rate_schedule(2.0, "InvalidScheduleName")
 


### PR DESCRIPTION
Before this change, `learning_rate` was always passed as the first argument to the schedule constructor. Now, `learning_rate` is not passed if the first argument is already configured in `decay_params`.

Closes #923.