### PR TITLE
Fix count_lines function when the file is gzipped

### DIFF
--- a/opennmt/tests/misc_test.py
+++ b/opennmt/tests/misc_test.py
@@ -1,4 +1,6 @@
+import gzip
 import itertools
+import os
 
 import numpy as np
 import tensorflow as tf
@@ -180,6 +182,16 @@ class MiscTest(tf.test.TestCase):
         self.assertEqual(config["2"], 3)
         with self.assertRaisesRegex(KeyError, "a_3"):
             _ = config["3"]
+
+    def testCountLinesGzip(self):
+        expected_num_lines = 42
+
+        path = os.path.join(self.get_temp_dir(), "file.gz")
+        with gzip.open(path, "wt") as f:
+            for i in range(expected_num_lines):
+                f.write("%d\n" % i)
+
+        self.assertEqual(misc.count_lines(path), expected_num_lines)
 
 
 if __name__ == "__main__":

--- a/opennmt/utils/misc.py
+++ b/opennmt/utils/misc.py
@@ -3,6 +3,7 @@
 import collections
 import copy
 import functools
+import gzip
 import heapq
 import io
 import os
@@ -221,7 +222,8 @@ def item_or_tuple(x):
 
 def count_lines(filename, buffer_size=65536):
     """Returns the number of lines of the file :obj:`filename`."""
-    with tf.io.gfile.GFile(filename, mode="rb") as f:
+    file_class = gzip.open if is_gzip_file(filename) else tf.io.gfile.GFile
+    with file_class(filename, mode="rb") as f:
         num_lines = 0
         while True:
             data = f.read(buffer_size)


### PR DESCRIPTION
Fixes #973.