### PR TITLE
Remove recording of the global gradient norm

### DIFF
--- a/opennmt/decoders/decoder.py
+++ b/opennmt/decoders/decoder.py
@@ -307,7 +307,6 @@ class Decoder(tf.keras.layers.Layer):
                 sampling_probability = None
             else:
                 fused_projection = False
-                tf.summary.scalar("sampling_probability", sampling_probability)
 
         batch_size, max_step, _ = misc.shape_list(inputs)
         inputs_ta = tf.TensorArray(inputs.dtype, size=max_step)


### PR DESCRIPTION
The reported norm was misleading because it did not take into account gradient accumulation and multi-GPU. Removing this feature for now.